### PR TITLE
Add envs_from_files: load env vars from external dotenv files

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,31 @@ services_overrides:
 
 The service name passed to the action (via `ecs_service` or `task_name`) determines which overrides are applied. Services not listed in `services_overrides` use the base configuration.
 
+### Sharing Env Vars Across YAMLs (`envs_from_files`)
+
+When several deploy YAMLs need the same block of env vars, factor them out into a `.env` file and reference it from each YAML instead of copy-pasting:
+
+```yaml
+envs_from_files:
+  - ./shared/common.env
+envs:
+  - DATABASE_URL: "postgresql://prod-host:5432/db"  # overrides common.env
+
+services_overrides:
+  api-service:
+    envs_from_files:
+      - ./shared/api.env  # appended to base list
+```
+
+**Format:** strict-minimal dotenv — `KEY=value`, blank lines, full-line `#` comments, surrounding `"…"`/`'…'` stripped. No `export`, no inline comments, no `${VAR}` interpolation, no escapes. Anything else is a parse error. See [`examples/envs-from-files.yaml`](./examples/envs-from-files.yaml).
+
+**Precedence (highest wins):**
+1. Inline `envs:` (base + per-service appended)
+2. Later files in `envs_from_files` override earlier files
+3. `envs_from_files` entries are appended per-service, same merge rule as `envs:`
+
+**Paths** are resolved relative to the YAML config file's directory. Absolute paths are also accepted. A missing file is a hard error.
+
 ## Architecture
 
 For scheduled tasks, the action:

--- a/examples/envs-from-files.yaml
+++ b/examples/envs-from-files.yaml
@@ -1,0 +1,27 @@
+# envs_from_files Test
+# Demonstrates loading env vars from external dotenv files, with the
+# precedence rule: file entries first (later files override earlier),
+# inline `envs:` always wins over files.
+name: envs-from-files-app
+replica_count: 1
+cpu: 256
+memory: 512
+role_arn: arn:aws:iam::123456789012:role/ecsTaskExecutionRole
+port: 8080
+
+# Base: every service inherits common.env, plus an inline override
+# that proves inline beats file values.
+envs_from_files:
+  - ./shared/common.env
+envs:
+  - DATABASE_URL: "postgresql://prod-host:5432/db"
+
+services_overrides:
+  test-service:
+    # Per-service: appends api.env (later in the merged list, so its
+    # LOG_LEVEL=debug wins over common.env's LOG_LEVEL=info), plus an
+    # extra inline env.
+    envs_from_files:
+      - ./shared/api.env
+    envs:
+      - WORKER_MODE: "true"

--- a/examples/shared/api.env
+++ b/examples/shared/api.env
@@ -1,0 +1,3 @@
+# API-specific env vars (overrides common.env on collisions)
+LOG_LEVEL=debug
+API_MODE=true

--- a/examples/shared/common.env
+++ b/examples/shared/common.env
@@ -1,0 +1,4 @@
+# Shared env vars for any service
+NODE_ENV=production
+LOG_LEVEL=info
+DATABASE_URL="postgresql://default-host:5432/db"

--- a/scripts/generate_task_def.py
+++ b/scripts/generate_task_def.py
@@ -2,6 +2,7 @@
 import yaml
 import json
 import argparse
+import re
 import sys
 import logging
 from typing import Dict, List, Optional, Any
@@ -121,7 +122,7 @@ def validate_config(config: Dict[str, Any]) -> None:
 
 # Fields that are arrays and should be extended (appended) during merge
 ARRAY_FIELDS = {
-    'command', 'entrypoint', 'envs', 'secrets', 'secrets_envs',
+    'command', 'entrypoint', 'envs', 'envs_from_files', 'secrets', 'secrets_envs',
     'secret_files', 'additional_ports', 'writable_dirs'
 }
 
@@ -210,6 +211,76 @@ def validate_services_overrides(config: Dict[str, Any]) -> None:
                 f"got {type(overrides).__name__}"
             )
 
+DOTENV_KEY_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+def parse_dotenv_file(path: Path) -> Dict[str, str]:
+    """Parse a strict-minimal dotenv file into an ordered dict.
+
+    Supported: KEY=value, blank lines, full-line `#` comments, surrounding
+    matched single/double quotes stripped. Anything else raises ValidationError.
+    Last occurrence of a key wins.
+    """
+    if not path.exists():
+        raise ValidationError(f"envs_from_files: file not found: {path}")
+
+    result: Dict[str, str] = {}
+    with path.open('r') as fh:
+        for lineno, raw_line in enumerate(fh, start=1):
+            line = raw_line.rstrip('\n').rstrip('\r')
+            stripped = line.strip()
+            if not stripped or stripped.startswith('#'):
+                continue
+            if '=' not in line:
+                raise ValidationError(f"{path}:{lineno}: invalid syntax (missing '=')")
+            key, value = line.split('=', 1)
+            key = key.strip()
+            if not DOTENV_KEY_RE.match(key):
+                raise ValidationError(f"{path}:{lineno}: invalid key {key!r}")
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                value = value[1:-1]
+            result[key] = value
+    return result
+
+def expand_envs_from_files(config: Dict[str, Any], yaml_path: Path) -> None:
+    """Resolve envs_from_files paths relative to the YAML, then merge entries
+    into config['envs']. File-derived values are overridden by inline envs;
+    later files in the list override earlier ones. Mutates config in place."""
+    file_refs = config.pop('envs_from_files', None)
+    if not file_refs:
+        return
+
+    if not isinstance(file_refs, list):
+        raise ValidationError(
+            f"envs_from_files must be a list, got {type(file_refs).__name__}"
+        )
+
+    yaml_dir = yaml_path.parent
+    merged: Dict[str, str] = {}
+    for ref in file_refs:
+        if not isinstance(ref, str):
+            raise ValidationError(
+                f"envs_from_files entries must be strings, got {type(ref).__name__}"
+            )
+        ref_path = Path(ref)
+        if not ref_path.is_absolute():
+            ref_path = (yaml_dir / ref_path).resolve()
+        merged.update(parse_dotenv_file(ref_path))
+
+    file_count = len(file_refs)
+    file_key_count = len(merged)
+
+    for entry in config.get('envs', []):
+        if not isinstance(entry, dict):
+            continue
+        for key, value in entry.items():
+            merged[key] = str(value)
+
+    config['envs'] = [{k: v} for k, v in merged.items()]
+    logger.info(
+        f"Loaded {file_key_count} env var(s) from {file_count} file(s) referenced by envs_from_files"
+    )
+
 def load_and_validate_config(yaml_file_path: str, service_name: Optional[str] = None) -> Dict[str, Any]:
     """Load and validate YAML configuration, applying service overrides if present"""
     try:
@@ -228,6 +299,11 @@ def load_and_validate_config(yaml_file_path: str, service_name: Optional[str] = 
 
         # Apply service-specific overrides if present
         config = apply_service_overrides(raw_config, service_name)
+
+        # Expand envs_from_files into the envs list (after merge so per-service
+        # entries are appended; before validation so the final envs list is what
+        # validate_config sees).
+        expand_envs_from_files(config, yaml_path)
 
         # Validate the final merged config
         validate_config(config)

--- a/tests/expected_outputs/envs-from-files.json
+++ b/tests/expected_outputs/envs-from-files.json
@@ -1,0 +1,64 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/test-app:latest",
+      "essential": true,
+      "environment": [
+        {
+          "name": "NODE_ENV",
+          "value": "production"
+        },
+        {
+          "name": "LOG_LEVEL",
+          "value": "debug"
+        },
+        {
+          "name": "DATABASE_URL",
+          "value": "postgresql://prod-host:5432/db"
+        },
+        {
+          "name": "API_MODE",
+          "value": "true"
+        },
+        {
+          "name": "WORKER_MODE",
+          "value": "true"
+        }
+      ],
+      "command": [],
+      "entryPoint": [],
+      "secrets": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "/default"
+        }
+      },
+      "portMappings": [
+        {
+          "name": "default",
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ]
+    }
+  ],
+  "cpu": "256",
+  "memory": "512",
+  "family": "test-cluster_test-service",
+  "taskRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "executionRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `envs_from_files: [path, ...]` to the task config YAML so multiple deploy YAMLs can share an env block via reusable `.env` files instead of copy-pasting.
- Strict-minimal dotenv parser; paths resolved relative to the YAML; precedence is later-file > earlier-file > inline-`envs:` always wins; per-service entries append (same merge as `envs:`); missing file is a hard error.
- Includes a worked multi-service example (`examples/envs-from-files.yaml` + `examples/shared/`), expected-output fixture, and README docs.

## Test plan
- [x] `python tests/test.py` — all 28 examples pass, no regressions on the 27 pre-existing fixtures
- [x] Manually verified missing-file → exit 1 with resolved absolute path
- [x] Manually verified URL with `#` fragment is preserved (no inline-comment handling)
- [x] Manually verified `export FOO=bar` is rejected with a clear key-validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)