### PR TITLE
Preserve Terraform-managed tag propagation across ECS deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Deploy standalone task definitions that can be triggered manually or by external
 | `aws_role` | The AWS IAM role to assume | No | `github_services` |
 | `dry_run` | Whether to perform a dry run | No | `false` |
 | `ecr_registry` | Use ECR registry for main container image | No | `true` |
+| `propagate_tags` | Where the service copies tags from when launching tasks (service mode only): `SERVICE` or `NONE` | No | `SERVICE` |
 
 ## Example Usage
 
@@ -246,6 +247,14 @@ For triggerable tasks, the action:
 2. Registers the new task definition with ECS
 
 All infrastructure (EventBridge rules, schedules, network configuration, IAM roles) remains managed in your Terraform code, ensuring clear separation of concerns between infrastructure and application deployments.
+
+## Task Tagging
+
+Tags are owned by Terraform, not by this action. The action never injects tags into the generated task definition or sources them from SSM — it only avoids clobbering the tag configuration Terraform sets.
+
+- **Service** — Terraform tags the ECS service and sets `propagate_tags = "SERVICE"`, so ECS copies those tags onto every launched task. The service deploy step passes `propagate-tags: SERVICE` (configurable via the `propagate_tags` input) so each deploy keeps that setting instead of resetting it to `NONE`.
+- **Scheduled task** — tags are set by Terraform on the EventBridge target (`aws_cloudwatch_event_target` → `ecs_target { tags = {...} }`, i.e. `EcsParameters.TagList`). The `update-eventbridge-target` step rewrites only `EcsParameters.TaskDefinitionArn`, so the target's `TagList` and `PropagateTags` survive each deploy.
+- **Triggerable task** — this action only registers the task definition; it does not run the task. The caller that launches it must pass the Terraform-owned tag set on `aws ecs run-task` via `--tags` (or `Tags` in the API), for example `aws ecs run-task --cluster <cluster> --task-definition <arn> --tags key=Team,value=platform ...`. Without `--tags`, the launched task is untagged.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,11 @@ inputs:
   dry_run:
     description: 'Whether to perform a dry run'
     default: 'false'
-    required: false 
+    required: false
+  propagate_tags:
+    description: 'Where the service copies tags from when launching tasks (service mode only). Set to SERVICE so Terraform-managed service tags propagate to tasks; use NONE to disable.'
+    default: 'SERVICE'
+    required: false
   ecr_registry:
     description: 'The ECR registry URL'
     required: false
@@ -106,6 +110,11 @@ runs:
         cluster: ${{ inputs.ecs_cluster }}
         desired-count: ${{ steps.generate-task-def.outputs.replica_count }}
         wait-for-service-stability: true
+        # Preserve the Terraform-managed propagate_tags setting on the service.
+        # amazon-ecs-deploy-task-definition always sends propagateTags in its
+        # UpdateService call; when unset AWS treats it as NONE and silently resets
+        # the service, wiping Terraform's SERVICE setting so tasks stop inheriting tags.
+        propagate-tags: ${{ inputs.propagate_tags }}
         
     - id: check-service-deployment
       if: ${{ inputs.deployment_type == 'service' && inputs.dry_run == 'false' }}


### PR DESCRIPTION
## Problem

Every **service** deploy silently reset the ECS service's tag propagation setting, so newly launched tasks stopped inheriting the service's tags.

The `aws-actions/amazon-ecs-deploy-task-definition@v2.6.1` step is called without a `propagate-tags` input. That action **always** includes `propagateTags` in its `UpdateService` request, defaulting it to `null` when the input is empty. AWS's `UpdateService` treats an unspecified `propagateTags` as *"do not propagate"*, so each deploy reset the service from `SERVICE` back to `NONE` — wiping what Terraform set. This also showed up as `terraform plan` drift on `propagate_tags`.

Tags are owned by Terraform (on the ECS service for services; on the EventBridge target / run-task caller for tasks). The action's only job here is to stop clobbering that configuration — it does **not** source tags from SSM and does **not** inject a `tags` block into the task definition.

## Changes

- **Service mode:** pass `propagate-tags: SERVICE` to the deploy step via a new optional `propagate_tags` input (defaults to `SERVICE`, wired only into the service step). This keeps the Terraform-managed setting instead of resetting it. This is the only code change.
- **Scheduled task mode:** unchanged. The `update-eventbridge-target` step already rewrites only `EcsParameters.TaskDefinitionArn`, so the target's Terraform-set `TagList`/`PropagateTags` survive each deploy. No task-def tag injection was added.
- **Triggerable task mode:** no code change. README now documents that any caller running the task via `aws ecs run-task` must pass the Terraform-owned tag set via `--tags`, since this action only registers the task definition.
- **README:** new "Task Tagging" section plus the `propagate_tags` input in the inputs table.

## Verification

- `service`: after a deploy, `aws ecs describe-services --query 'services[0].propagateTags'` returns `SERVICE`; new tasks carry the service's tags; `terraform plan` shows no drift on `propagate_tags`.
- `scheduled_task`: the EventBridge target keeps its Terraform-set `EcsParameters.TagList` (`aws events list-targets-by-rule`); rule-launched tasks carry those tags.
- `triggerable_task`: README documents the `run-task --tags` requirement.

Existing task-definition generation is untouched; the generated task definition remains tagless by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Akff7xTzDKdj2cdjp5RdG9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Akff7xTzDKdj2cdjp5RdG9)_