### PR TITLE
Add unit tests and improve secret/GitHub Actions handling

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ]
 }

--- a/.github/workflows/test-and-update.yml
+++ b/.github/workflows/test-and-update.yml
@@ -25,7 +25,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+
+    - name: Run unit tests
+      run: pytest tests/test_unit.py
 
     - name: Run tests and update expected outputs
       run: python tests/test.py

--- a/.github/workflows/test-and-update.yml
+++ b/.github/workflows/test-and-update.yml
@@ -3,10 +3,14 @@ name: Test and Update Expected Outputs
 on:
   pull_request:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   test-and-update:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v6
       with:
@@ -27,6 +31,9 @@ jobs:
       run: python tests/test.py
 
     - name: Commit and push changes
+      # Forked-PR runs get a read-only GITHUB_TOKEN and cannot push, which would
+      # fail the job for outside contributors. Only auto-commit for same-repo PRs.
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: stefanzweifel/git-auto-commit-action@v7
       id: auto_commit
       with:

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
     default: 'SERVICE'
     required: false
   ecr_registry:
-    description: 'The ECR registry URL'
+    description: "Whether the main application image lives in the account's ECR registry. Set to 'true' (default) to prefix the image with the ECR registry URL; set to 'false' for a public/external image. OTEL and Fluent Bit sidecars always use ECR regardless of this flag."
     required: false
     default: 'true'
 
@@ -61,43 +61,62 @@ runs:
     - id: login_ecr
       uses: aws-actions/amazon-ecr-login@v2
     - id: define-registry
+      env:
+        ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+        USE_ECR_REGISTRY: ${{ inputs.ecr_registry }}
       run: |
         # Always set registry for OTEL/Fluent Bit (they're always ECR)
-        echo "registry=${{ steps.login_ecr.outputs.registry }}" >> $GITHUB_OUTPUT
-        
+        echo "registry=$ECR_REGISTRY" >> "$GITHUB_OUTPUT"
+
         # Set container_registry only if ecr_registry is true (for main app)
-        if [ "${{ inputs.ecr_registry }}" == "true" ]; then
-          echo "container_registry=${{ steps.login_ecr.outputs.registry }}" >> $GITHUB_OUTPUT
+        if [ "$USE_ECR_REGISTRY" == "true" ]; then
+          echo "container_registry=$ECR_REGISTRY" >> "$GITHUB_OUTPUT"
         else
-          echo "container_registry=" >> $GITHUB_OUTPUT
+          echo "container_registry=" >> "$GITHUB_OUTPUT"
         fi
       shell: bash
 
     - id: install_dependencies
+      env:
+        ACTION_PATH: ${{ github.action_path }}
       run: |
-        python3 -m pip install -r ${{ github.action_path }}/requirements.txt
+        python3 -m pip install -r "$ACTION_PATH/requirements.txt"
       shell: bash
 
     - id: determine-name
+      env:
+        DEPLOYMENT_TYPE: ${{ inputs.deployment_type }}
+        TASK_NAME: ${{ inputs.task_name }}
+        ECS_SERVICE: ${{ inputs.ecs_service }}
       run: |
-        if [ "${{ inputs.deployment_type }}" == "scheduled_task" ] || [ "${{ inputs.deployment_type }}" == "triggerable_task" ]; then
-          echo "name=${{ inputs.task_name }}" >> $GITHUB_OUTPUT
+        if [ "$DEPLOYMENT_TYPE" == "scheduled_task" ] || [ "$DEPLOYMENT_TYPE" == "triggerable_task" ]; then
+          echo "name=$TASK_NAME" >> "$GITHUB_OUTPUT"
         else
-          echo "name=${{ inputs.ecs_service }}" >> $GITHUB_OUTPUT
+          echo "name=$ECS_SERVICE" >> "$GITHUB_OUTPUT"
         fi
       shell: bash
 
     - id: generate-task-def
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        TASK_CONFIG_YAML: ${{ inputs.task_config_yaml }}
+        ECS_CLUSTER: ${{ inputs.ecs_cluster }}
+        AWS_REGION: ${{ inputs.aws_region }}
+        REGISTRY: ${{ steps.define-registry.outputs.registry }}
+        CONTAINER_REGISTRY: ${{ steps.define-registry.outputs.container_registry }}
+        IMAGE_NAME: ${{ inputs.image_name }}
+        TAG: ${{ inputs.tag }}
+        DEPLOY_NAME: ${{ steps.determine-name.outputs.name }}
       run: |
-        python3 ${{ github.action_path }}/scripts/generate_task_def.py \
-          "${{ inputs.task_config_yaml }}" \
-          "${{ inputs.ecs_cluster }}" \
-          "${{ inputs.aws_region }}" \
-          "${{ steps.define-registry.outputs.registry }}" \
-          "${{ steps.define-registry.outputs.container_registry }}" \
-          "${{ inputs.image_name }}" \
-          "${{ inputs.tag }}" \
-          "${{ steps.determine-name.outputs.name }}"
+        python3 "$ACTION_PATH/scripts/generate_task_def.py" \
+          "$TASK_CONFIG_YAML" \
+          "$ECS_CLUSTER" \
+          "$AWS_REGION" \
+          "$REGISTRY" \
+          "$CONTAINER_REGISTRY" \
+          "$IMAGE_NAME" \
+          "$TAG" \
+          "$DEPLOY_NAME"
       shell: bash
 
     # ECS Service Deployment
@@ -118,9 +137,12 @@ runs:
         
     - id: check-service-deployment
       if: ${{ inputs.deployment_type == 'service' && inputs.dry_run == 'false' }}
+      env:
+        ECS_CLUSTER: ${{ inputs.ecs_cluster }}
+        ECS_SERVICE: ${{ inputs.ecs_service }}
+        NEW_TASK_DEF_ARN: ${{ steps.ecs-deploy-service.outputs.task-definition-arn }}
       run: |
-         CURRENT_TASK_DEF_ARN=$(aws ecs describe-services --cluster ${{ inputs.ecs_cluster }} --services ${{ inputs.ecs_service }} --query services[0].deployments[0].taskDefinition | jq -r ".")
-         NEW_TASK_DEF_ARN=${{ steps.ecs-deploy-service.outputs.task-definition-arn }}
+         CURRENT_TASK_DEF_ARN=$(aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" --query 'services[0].deployments[0].taskDefinition' --output text)
          echo "Current task arn: $CURRENT_TASK_DEF_ARN"
          echo "New task arn: $NEW_TASK_DEF_ARN"
          if [ "$CURRENT_TASK_DEF_ARN" != "$NEW_TASK_DEF_ARN" ]; then
@@ -144,26 +166,36 @@ runs:
 
     - id: update-eventbridge-target
       if: ${{ inputs.deployment_type == 'scheduled_task' && inputs.dry_run == 'false' }}
+      env:
+        ECS_CLUSTER: ${{ inputs.ecs_cluster }}
+        TASK_NAME: ${{ inputs.task_name }}
+        NEW_TASK_DEF_ARN: ${{ steps.register-task-def.outputs.task_definition_arn }}
       run: |
+        set -euo pipefail
         # Construct EventBridge rule name using same pattern as Terraform
-        EVENT_RULE_NAME="${{ inputs.ecs_cluster }}-${{ inputs.task_name }}"
-        
+        EVENT_RULE_NAME="${ECS_CLUSTER}-${TASK_NAME}"
+
         echo "Using EventBridge rule: $EVENT_RULE_NAME"
-        
+
         # Get current target configuration
         CURRENT_TARGETS=$(aws events list-targets-by-rule \
           --rule "$EVENT_RULE_NAME" \
           --query 'Targets[0]')
-        
+
+        if [ -z "$CURRENT_TARGETS" ] || [ "$CURRENT_TARGETS" == "null" ]; then
+          echo "❌ No existing target found for EventBridge rule $EVENT_RULE_NAME" >&2
+          exit 1
+        fi
+
         # Update only the TaskDefinitionArn, keeping all other config
-        UPDATED_TARGETS=$(echo $CURRENT_TARGETS | jq \
-          --arg new_arn "${{ steps.register-task-def.outputs.task_definition_arn }}" \
+        UPDATED_TARGETS=$(echo "$CURRENT_TARGETS" | jq \
+          --arg new_arn "$NEW_TASK_DEF_ARN" \
           '.EcsParameters.TaskDefinitionArn = $new_arn')
-        
+
         # Put the updated target back
         aws events put-targets \
           --rule "$EVENT_RULE_NAME" \
           --targets "$UPDATED_TARGETS"
-        
-        echo "✅ Updated EventBridge rule $EVENT_RULE_NAME to task definition ${{ steps.register-task-def.outputs.task_definition_arn }}"
+
+        echo "✅ Updated EventBridge rule $EVENT_RULE_NAME to task definition $NEW_TASK_DEF_ARN"
       shell: bash

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Development / CI-only dependencies (not needed at action runtime)
+-r requirements.txt
+pytest>=7.0

--- a/scripts/generate_task_def.py
+++ b/scripts/generate_task_def.py
@@ -2,6 +2,7 @@
 import yaml
 import json
 import argparse
+import os
 import re
 import sys
 import logging
@@ -386,7 +387,18 @@ class ContainerBuilder:
 
 class SecretManager:
     """Handle secrets configuration"""
-    
+
+    @staticmethod
+    def _mock_allowed() -> bool:
+        """Whether mock secret keys/ARNs may be substituted on lookup failure.
+
+        Mock fallbacks exist so the test suite can run without AWS credentials.
+        In a real deploy they must NEVER be used silently, otherwise a transient
+        AWS error or an IAM permission gap would bake fabricated secret ARNs into
+        the task definition. Enable only for local/offline testing.
+        """
+        return os.environ.get("ECS_DEPLOY_ALLOW_MOCK_SECRETS", "").strip().lower() in ("1", "true", "yes")
+
     @staticmethod
     def discover_secret_keys(secret_name: str) -> tuple[List[str], str]:
         """Discover all keys in a secret by querying AWS Secrets Manager
@@ -418,35 +430,36 @@ class SecretManager:
                 logger.warning(f"Secret '{secret_name}' does not contain a JSON object")
                 return [], full_secret_arn
                 
-        except (NoCredentialsError, PartialCredentialsError, TokenRetrievalError):
-            # For testing environments where AWS credentials aren't available or expired
-            logger.warning(f"AWS credentials not available or expired. Using mock keys for secret '{secret_name}'")
-            keys = SecretManager._get_mock_keys(secret_name)
-            mock_arn = SecretManager._get_mock_arn(secret_name)
-            return keys, mock_arn
-        except ClientError as e:
-            error_code = e.response['Error']['Code']
+        except (NoCredentialsError, PartialCredentialsError, TokenRetrievalError) as exc:
+            return SecretManager._handle_discovery_failure(
+                secret_name,
+                "AWS credentials are unavailable or expired",
+                exc,
+            )
+        except ClientError as exc:
+            error_code = exc.response['Error']['Code']
             if error_code == 'ResourceNotFoundException':
-                logger.error(f"Secret '{secret_name}' not found")
-                # Fall back to mock keys for testing
-                logger.warning(f"Falling back to mock keys for secret '{secret_name}'")
-                keys = SecretManager._get_mock_keys(secret_name)
-                mock_arn = SecretManager._get_mock_arn(secret_name)
-                return keys, mock_arn
+                reason = f"secret '{secret_name}' was not found"
             else:
-                logger.error(f"AWS error discovering keys for secret '{secret_name}': {e}")
-                # Fall back to mock keys for testing
-                logger.warning(f"Falling back to mock keys for secret '{secret_name}'")
-                keys = SecretManager._get_mock_keys(secret_name)
-                mock_arn = SecretManager._get_mock_arn(secret_name)
-                return keys, mock_arn
-        except Exception as e:
-            logger.error(f"Error discovering keys for secret '{secret_name}': {e}")
-            # Fall back to mock keys for testing
-            logger.warning(f"Falling back to mock keys for secret '{secret_name}'")
-            keys = SecretManager._get_mock_keys(secret_name)
-            mock_arn = SecretManager._get_mock_arn(secret_name)
-            return keys, mock_arn
+                reason = f"AWS error ({error_code})"
+            return SecretManager._handle_discovery_failure(secret_name, reason, exc)
+        except Exception as exc:
+            return SecretManager._handle_discovery_failure(secret_name, str(exc), exc)
+
+    @staticmethod
+    def _handle_discovery_failure(secret_name: str, reason: str, exc: Exception) -> tuple[List[str], str]:
+        """Either substitute mock values (test mode) or fail loudly (real deploy)."""
+        if SecretManager._mock_allowed():
+            logger.warning(
+                f"Secret discovery for '{secret_name}' failed ({reason}); using mock keys "
+                f"because ECS_DEPLOY_ALLOW_MOCK_SECRETS is set"
+            )
+            return SecretManager._get_mock_keys(secret_name), SecretManager._get_mock_arn(secret_name)
+        raise ValidationError(
+            f"Failed to discover keys for secret '{secret_name}': {reason}. "
+            f"Refusing to substitute mock secret values in a real deploy. "
+            f"Set ECS_DEPLOY_ALLOW_MOCK_SECRETS=1 only for local/offline testing."
+        ) from exc
     
     @staticmethod
     def _get_mock_keys(secret_name: str) -> List[str]:
@@ -511,23 +524,22 @@ class SecretManager:
             secret_name = secret_config.get('name', '')
             secret_values = secret_config.get('values', [])
             
-            # Handle name-only format (new feature) - query AWS to get keys
+            # Handle name-only format (new feature) - query AWS to get keys.
+            # Any discovery failure raises ValidationError (see discover_secret_keys)
+            # and is intentionally allowed to propagate so the deploy fails loudly
+            # rather than emitting a task definition with missing/mock secrets.
             if secret_name and not secret_id and not secret_values:
-                try:
-                    # Query AWS Secrets Manager to discover keys in this secret
-                    discovered_keys, full_secret_arn = SecretManager.discover_secret_keys(secret_name)
-                    if discovered_keys:
-                        for key in discovered_keys:
-                            secrets.append({
-                                "name": key,
-                                "valueFrom": f"{full_secret_arn}:{key}::"
-                            })
-                        logger.info(f"Auto-discovered {len(discovered_keys)} keys from secret '{secret_name}': {discovered_keys}")
-                        logger.info(f"Using full secret ARN: {full_secret_arn}")
-                    else:
-                        logger.warning(f"No keys found in secret '{secret_name}'")
-                except Exception as e:
-                    logger.error(f"Failed to discover keys for secret '{secret_name}': {e}")
+                discovered_keys, full_secret_arn = SecretManager.discover_secret_keys(secret_name)
+                if discovered_keys:
+                    for key in discovered_keys:
+                        secrets.append({
+                            "name": key,
+                            "valueFrom": f"{full_secret_arn}:{key}::"
+                        })
+                    logger.info(f"Auto-discovered {len(discovered_keys)} keys from secret '{secret_name}': {discovered_keys}")
+                    logger.info(f"Using full secret ARN: {full_secret_arn}")
+                else:
+                    logger.warning(f"No keys found in secret '{secret_name}'")
                 continue
             
             # Handle traditional id + values format
@@ -1321,9 +1333,15 @@ def main() -> None:
         
         logger.info(f"Task definition written to {output_path}")
         
-        # Output for GitHub Actions (to stderr so it doesn't interfere with JSON output)
+        # Emit replica_count as a GitHub Actions step output via $GITHUB_OUTPUT.
+        # The legacy ::set-output workflow command is deprecated and disabled by
+        # GitHub, and was additionally being written to stderr (which Actions never
+        # parses), so the output was silently never set.
         replica_count = config.get('replica_count', '')
-        print(f"::set-output name=replica_count::{replica_count}", file=sys.stderr)
+        github_output = os.environ.get("GITHUB_OUTPUT")
+        if github_output:
+            with open(github_output, "a") as gh_out:
+                gh_out.write(f"replica_count={replica_count}\n")
         
         # Output JSON to stdout for tests and compatibility
         print(json.dumps(task_definition, indent=2))

--- a/scripts/generate_task_def.py
+++ b/scripts/generate_task_def.py
@@ -7,48 +7,11 @@ import re
 import sys
 import logging
 from typing import Dict, List, Optional, Any
-from dataclasses import dataclass, field
 from pathlib import Path
-from enum import Enum
-
-class LogLevel(Enum):
-    DEBUG = "DEBUG"
-    INFO = "INFO"
-    WARNING = "WARNING"
-    ERROR = "ERROR"
 
 class ValidationError(Exception):
     """Custom exception for validation errors"""
     pass
-
-@dataclass
-class TaskConfig:
-    """Configuration for ECS task definition"""
-    name: str
-    cpu: str = "256"
-    memory: str = "512"
-    cpu_arch: str = "X86_64"
-    command: List[str] = field(default_factory=list)
-    entrypoint: List[str] = field(default_factory=list)
-    port: Optional[int] = None
-    additional_ports: List[Dict[str, int]] = field(default_factory=list)
-    role_arn: str = ""
-    replica_count: str = ""
-    
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'TaskConfig':
-        return cls(
-            name=data.get('name', 'app'),
-            cpu=str(data.get('cpu', 256)),
-            memory=str(data.get('memory', 512)),
-            cpu_arch=data.get('cpu_arch', 'X86_64'),
-            command=data.get('command', []),
-            entrypoint=data.get('entrypoint', []),
-            port=data.get('port'),
-            additional_ports=data.get('additional_ports', []),
-            role_arn=data.get('role_arn', ''),
-            replica_count=data.get('replica_count', '')
-        )
 
 def setup_logging(level: str = "INFO") -> logging.Logger:
     """Setup logging configuration"""
@@ -125,11 +88,6 @@ def validate_config(config: Dict[str, Any]) -> None:
 ARRAY_FIELDS = {
     'command', 'entrypoint', 'envs', 'envs_from_files', 'secrets', 'secrets_envs',
     'secret_files', 'additional_ports', 'writable_dirs'
-}
-
-# Fields that are objects and use shallow merge (replace)
-OBJECT_FIELDS = {
-    'health_check', 'linux_parameters', 'otel_collector', 'fluent_bit_collector'
 }
 
 def merge_configs(base_config: Dict[str, Any], service_override: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test.py
+++ b/tests/test.py
@@ -61,42 +61,29 @@ def run_script_for_yaml(yaml_file, script_path):
         service_name
     ]
     
+    # The generator refuses to substitute mock secret values unless explicitly
+    # allowed. Tests run without AWS credentials, so opt in here (and only here).
+    env = {**os.environ, "ECS_DEPLOY_ALLOW_MOCK_SECRETS": "1"}
+
     try:
         print(f"Running: {' '.join(cmd)}")
-        result = subprocess.run(cmd, capture_output=True, text=True, cwd=get_project_root())
-        
+        result = subprocess.run(cmd, capture_output=True, text=True, cwd=get_project_root(), env=env)
+
         if result.returncode != 0:
             print(f"Script failed with return code {result.returncode}")
             print(f"STDERR: {result.stderr}")
             print(f"STDOUT: {result.stdout}")
             return None
-        
-        # Parse the JSON output from stdout
+
+        # The generator prints the task definition JSON (and nothing else) to stdout;
+        # all logs go to stderr.
         try:
-            # The script prints the JSON between specific markers
-            lines = result.stdout.split('\n')
-            json_start = None
-            json_end = None
-            
-            for i, line in enumerate(lines):
-                if "----- Task Definition -----" in line:
-                    json_start = i + 1
-                elif "---------------------------" in line and json_start is not None:
-                    json_end = i
-                    break
-            
-            if json_start is not None and json_end is not None:
-                json_text = '\n'.join(lines[json_start:json_end])
-                return json.loads(json_text)
-            else:
-                # Fallback: try to parse the entire stdout as JSON
-                return json.loads(result.stdout)
-                
+            return json.loads(result.stdout)
         except json.JSONDecodeError as e:
             print(f"Failed to parse JSON output: {e}")
             print(f"Output was: {result.stdout}")
             return None
-            
+
     except Exception as e:
         print(f"Exception running script: {e}")
         return None
@@ -202,9 +189,14 @@ def main():
     
     print(f"Found {len(yaml_files)} YAML files")
     
+    # In CI, a missing expected-output file is a failure: the baseline must be
+    # committed and reviewed, not silently generated from whatever the script
+    # currently emits. Locally, auto-create for convenience.
+    ci_mode = os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS") or "--check" in sys.argv
+
     failed_tests = []
     created_files = []
-    
+
     for yaml_file in yaml_files:
         print(f"\n{'='*60}")
         print(f"Processing: {yaml_file.name}")
@@ -225,8 +217,11 @@ def main():
         expected_output = load_expected_json(expected_json_file)
         
         if expected_output is None:
-            # Create the expected output file
-            if save_json_output(actual_output, expected_json_file):
+            if ci_mode:
+                print(f"❌ FAILED: {yaml_file.name} - No expected output baseline "
+                      f"({json_filename}). Generate and commit it locally first.")
+                failed_tests.append(yaml_file.name)
+            elif save_json_output(actual_output, expected_json_file):
                 print(f"✅ CREATED: {yaml_file.name} - Expected output file created")
                 created_files.append(json_filename)
             else:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Unit tests for the pure logic in scripts/generate_task_def.py.
+
+These complement the YAML->JSON snapshot tests in test.py by asserting on the
+individual building blocks (validation, config merge, dotenv parsing, image
+parsing, secret building) including their failure paths.
+
+Run with: pytest tests/test_unit.py
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the generator importable regardless of the working directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import generate_task_def as g  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# validate_config
+# --------------------------------------------------------------------------- #
+def test_validate_config_valid_fargate():
+    g.validate_config({"launch_type": "FARGATE", "cpu": 256, "memory": 512})
+
+
+def test_validate_config_invalid_launch_type():
+    with pytest.raises(g.ValidationError):
+        g.validate_config({"launch_type": "SERVERLESS"})
+
+
+def test_validate_config_fargate_requires_awsvpc():
+    with pytest.raises(g.ValidationError):
+        g.validate_config({"launch_type": "FARGATE", "network_mode": "bridge"})
+
+
+def test_validate_config_invalid_cpu_memory_combo():
+    with pytest.raises(g.ValidationError):
+        g.validate_config({"launch_type": "FARGATE", "cpu": 256, "memory": 4096})
+
+
+def test_validate_config_ec2_flexible_but_positive():
+    g.validate_config({"launch_type": "EC2", "network_mode": "bridge", "cpu": 100, "memory": 100})
+    with pytest.raises(g.ValidationError):
+        g.validate_config({"launch_type": "EC2", "cpu": -1})
+
+
+# --------------------------------------------------------------------------- #
+# merge_configs — arrays extend, scalars/objects replace, null removes
+# --------------------------------------------------------------------------- #
+def test_merge_arrays_extend():
+    merged = g.merge_configs({"envs": [{"A": "1"}]}, {"envs": [{"B": "2"}]})
+    assert merged["envs"] == [{"A": "1"}, {"B": "2"}]
+
+
+def test_merge_scalar_replaces():
+    merged = g.merge_configs({"cpu": 256}, {"cpu": 512})
+    assert merged["cpu"] == 512
+
+
+def test_merge_object_replaces():
+    merged = g.merge_configs(
+        {"health_check": {"command": "old", "interval": 30}},
+        {"health_check": {"command": "new"}},
+    )
+    assert merged["health_check"] == {"command": "new"}
+
+
+def test_merge_null_removes_field():
+    merged = g.merge_configs({"port": 8080}, {"port": None})
+    assert "port" not in merged
+
+
+def test_merge_strips_services_overrides():
+    merged = g.merge_configs({"cpu": 256, "services_overrides": {"x": {}}}, {})
+    assert "services_overrides" not in merged
+
+
+# --------------------------------------------------------------------------- #
+# parse_dotenv_file
+# --------------------------------------------------------------------------- #
+def test_parse_dotenv_basic(tmp_path):
+    p = tmp_path / ".env"
+    p.write_text("# comment\nFOO=bar\n\nBAZ='qux'\nQUOTED=\"v a l\"\n")
+    assert g.parse_dotenv_file(p) == {"FOO": "bar", "BAZ": "qux", "QUOTED": "v a l"}
+
+
+def test_parse_dotenv_last_key_wins(tmp_path):
+    p = tmp_path / ".env"
+    p.write_text("K=1\nK=2\n")
+    assert g.parse_dotenv_file(p) == {"K": "2"}
+
+
+def test_parse_dotenv_missing_equals_raises(tmp_path):
+    p = tmp_path / ".env"
+    p.write_text("NOT_VALID\n")
+    with pytest.raises(g.ValidationError):
+        g.parse_dotenv_file(p)
+
+
+def test_parse_dotenv_invalid_key_raises(tmp_path):
+    p = tmp_path / ".env"
+    p.write_text("1BAD=x\n")
+    with pytest.raises(g.ValidationError):
+        g.parse_dotenv_file(p)
+
+
+def test_parse_dotenv_missing_file_raises(tmp_path):
+    with pytest.raises(g.ValidationError):
+        g.parse_dotenv_file(tmp_path / "nope.env")
+
+
+# --------------------------------------------------------------------------- #
+# parse_image_parts
+# --------------------------------------------------------------------------- #
+def test_parse_image_strips_registry():
+    name, tag = g.parse_image_parts("123.dkr.ecr.us-east-1.amazonaws.com/my-app", "latest")
+    assert name == "my-app"
+    assert tag == "latest"
+
+
+def test_parse_image_extracts_embedded_tag():
+    name, tag = g.parse_image_parts("my-app:v2", "")
+    assert name == "my-app"
+    assert tag == "v2"
+
+
+def test_parse_image_explicit_tag_wins():
+    name, tag = g.parse_image_parts("my-app:v2", "v3")
+    assert name == "my-app"
+    assert tag == "v3"
+
+
+# --------------------------------------------------------------------------- #
+# build_secrets_from_config
+# --------------------------------------------------------------------------- #
+def test_build_secrets_legacy_format():
+    secrets = g.SecretManager.build_secrets_from_config(
+        {"secrets": [{"DB_PASS": "arn:aws:secretsmanager:...:secret:db"}]}
+    )
+    assert secrets == [{"name": "DB_PASS", "valueFrom": "arn:aws:secretsmanager:...:secret:db:DB_PASS::"}]
+
+
+def test_build_secrets_new_id_values_format():
+    secrets = g.SecretManager.build_secrets_from_config(
+        {"secrets_envs": [{"id": "arn:secret:app", "values": ["A", "B"]}]}
+    )
+    assert secrets == [
+        {"name": "A", "valueFrom": "arn:secret:app:A::"},
+        {"name": "B", "valueFrom": "arn:secret:app:B::"},
+    ]
+
+
+def test_name_only_secret_fails_loudly_without_mock(monkeypatch):
+    # No opt-in flag: a name-only lookup that can't reach AWS must raise, not
+    # silently emit fabricated ARNs.
+    monkeypatch.delenv("ECS_DEPLOY_ALLOW_MOCK_SECRETS", raising=False)
+
+    def boom(secret_name):
+        raise RuntimeError("no network")
+
+    monkeypatch.setattr(
+        g.SecretManager, "discover_secret_keys", staticmethod(boom)
+    )
+    with pytest.raises((g.ValidationError, RuntimeError)):
+        g.SecretManager.build_secrets_from_config(
+            {"secrets_envs": [{"name": "database-credentials"}]}
+        )
+
+
+def test_mock_allowed_toggle(monkeypatch):
+    monkeypatch.setenv("ECS_DEPLOY_ALLOW_MOCK_SECRETS", "1")
+    assert g.SecretManager._mock_allowed() is True
+    monkeypatch.setenv("ECS_DEPLOY_ALLOW_MOCK_SECRETS", "false")
+    assert g.SecretManager._mock_allowed() is False
+    monkeypatch.delenv("ECS_DEPLOY_ALLOW_MOCK_SECRETS", raising=False)
+    assert g.SecretManager._mock_allowed() is False
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
This PR adds comprehensive unit tests for the task definition generator and improves error handling for secrets discovery and GitHub Actions output. It also refactors the secret manager to fail loudly on AWS errors in production while allowing mock values only in test mode.

## Key Changes

### Testing Infrastructure
- **New unit test suite** (`tests/test_unit.py`): 20+ tests covering validation, config merging, dotenv parsing, image parsing, and secrets building with both success and failure paths
- **New dev dependencies** (`requirements-dev.txt`): Added pytest for running unit tests
- **CI workflow updates** (`.github/workflows/test-and-update.yml`): 
  - Added unit test step before integration tests
  - Added permissions for auto-commit on same-repo PRs only (forked PRs get read-only token)
  - Installs from `requirements-dev.txt` instead of `requirements.txt`

### Secrets Manager Improvements
- **New `_mock_allowed()` method**: Checks `ECS_DEPLOY_ALLOW_MOCK_SECRETS` environment variable to determine if mock secret values are permitted (test mode only)
- **New `_handle_discovery_failure()` method**: Centralizes error handling—either substitutes mock values (if allowed) or raises `ValidationError` with clear guidance
- **Fail-loud behavior**: In production (real deploys), any AWS credential or secret discovery error now raises immediately rather than silently using mock values, preventing transient AWS errors or IAM gaps from baking fabricated ARNs into task definitions
- **Simplified error paths**: Removed redundant try-catch blocks in `build_secrets_from_config()`; discovery failures now propagate as `ValidationError` and are intentionally not caught

### GitHub Actions Output Fix
- **Replaced deprecated `::set-output`**: Now writes to `$GITHUB_OUTPUT` file (GitHub's current standard) instead of the deprecated workflow command that was being written to stderr and never parsed
- **Conditional output**: Only writes if `GITHUB_OUTPUT` environment variable is set (graceful fallback for local runs)

### Action Workflow Improvements (`action.yml`)
- **Improved `ecr_registry` description**: Clarified that it controls whether the main app image uses ECR (sidecars always use ECR)
- **Better shell quoting**: All variable references now properly quoted to handle spaces and special characters
- **Enhanced error handling**: EventBridge target update now validates that targets exist before attempting update, with explicit error message on failure
- **Stricter bash mode**: Added `set -euo pipefail` to EventBridge step for fail-fast behavior

### Test Suite Improvements (`tests/test.py`)
- **Cleaner JSON parsing**: Removed complex marker-based parsing; now directly parses stdout as JSON (generator outputs only JSON to stdout, logs to stderr)
- **CI mode detection**: Distinguishes between CI (fails on missing baselines) and local (auto-creates baselines) using `CI` or `GITHUB_ACTIONS` env vars or `--check` flag
- **Mock secrets enabled**: Tests now set `ECS_DEPLOY_ALLOW_MOCK_SECRETS=1` when running the generator

### Code Cleanup
- Removed unused `TaskConfig` dataclass and `LogLevel` enum from `generate_task_def.py`
- Removed unused `OBJECT_FIELDS` constant
- Removed unused imports (`dataclasses`, `Enum`)

## Notable Implementation Details
- The mock secrets feature is now explicitly opt-in via environment variable, making the test/production distinction clear and preventing accidental use of mock values in real deployments
- Unit tests can run without AWS credentials by setting `ECS_DEPLOY_ALLOW_MOCK_SECRETS=1`
- Integration tests in CI will fail if expected output baselines are missing (preventing silent generation of new baselines), but local runs auto-create them for developer convenience

https://claude.ai/code/session_01KFbed6Rx8MdTWjNX5sE73U