### PR TITLE
feat: add generic sidecar support to task_config_yaml

### DIFF
--- a/.github/workflows/test-and-update.yml
+++ b/.github/workflows/test-and-update.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Run role resolution tests
       run: python tests/test_roles.py
 
+    - name: Run sidecar tests
+      run: python tests/test_sidecars.py
+
     - name: Run task definition tests
       # Deliberately without UPDATE_EXPECTED, so a missing expected output fails
       # the build instead of being fabricated here and auto-committed - which
@@ -61,3 +64,4 @@ jobs:
         # Re-run to ensure everything still passes after any auto-committed update.
         python tests/test.py
         python tests/test_roles.py
+        python tests/test_sidecars.py

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This GitHub Action automates the deployment of containerized applications to Ama
 - EventBridge scheduled task support
 - Configurable deployment parameters
 - Support for OpenTelemetry and Fluent Bit sidecars
+- **Generic sidecar containers** with per-container read-only root filesystems and strict isolation
 - Secrets management integration
 - Integration with GitHub Actions workflow
 - **EC2 and Fargate launch type support**
@@ -166,6 +167,7 @@ The action uses a simplified YAML configuration file for task definitions. See t
 - Health checks
 - Port mappings
 - OpenTelemetry and Fluent Bit integration
+- [Generic sidecars](./docs/sidecars.md) (extra containers with their own env, secrets, mounts and read-only setting)
 - [Task and execution roles](./docs/roles.md) (explicit ARNs or automatic discovery from SSM)
 - [EC2 launch type support](./docs/ec2-launch-type.md) (with bridge/host network modes)
 - [Linux parameters](./docs/linux-parameters.md) (init process, capabilities, shared memory, devices)

--- a/docs/sidecars.md
+++ b/docs/sidecars.md
@@ -1,0 +1,276 @@
+# Sidecars
+
+A `sidecars:` list adds extra containers to the generated task definition. They are ordinary ECS
+containers with their own image, environment, secrets, mounts, ports and health check — useful for
+a metrics agent, a cache, a log tailer, or a small writable container so the ECS Exec managed agent
+has somewhere to run while the application keeps a read-only root filesystem.
+
+Everything ends up in the **single** `task-definition.json` this action already registers. There is
+no second registration and no second deployment.
+
+> This is separate from `fluent_bit_collector` and `otel_collector`, which remain dedicated blocks
+> with their own defaults. Those are unchanged.
+
+## Minimal example
+
+```yaml
+cpu: 256
+memory: 512
+port: 8080
+
+sidecars:
+  - name: metrics-proxy
+    image: public.ecr.aws/nginx/nginx:1.27
+```
+
+That is enough. The container is `essential: true` (the ECS default), has no environment, no
+secrets, no mounts and no ports, and logs to the service's CloudWatch log group under the stream
+prefix `metrics-proxy`.
+
+## Isolation: a sidecar gets only what it declares
+
+This is the rule that matters most. A sidecar **never** inherits the application container's
+`envs`, `envs_from_files`, `secrets`, `secrets_envs`, `secret_files`, `writable_dirs`, `port`,
+`additional_ports`, `health_check` or `linux_parameters`. If a sidecar needs an environment
+variable or a secret, declare it inside that sidecar's own block.
+
+The single exception is `readonly_root_filesystem`, which falls back to the top-level value when
+the sidecar does not state one of its own — see [Read-only root filesystems](#read-only-root-filesystems).
+
+## Schema
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `name` | string | **required** | ECS container name. Must be unique — see [Reserved names](#reserved-and-generated-names). |
+| `image` | string | **required** | Full image reference. Pin sidecars by digest: nothing in this pipeline rebuilds them. |
+| `enabled` | bool | `true` | `false` removes the container. Mainly for per-service overrides. |
+| `essential` | bool | `true` | `false` lets the container exit without failing the task. |
+| `command` | list | `[]` | → `command` |
+| `entrypoint` | list | `[]` | → `entryPoint` |
+| `envs` | list of single-key maps | `[]` | → `environment`. Values are stringified, as for the app. |
+| `envs_from_files` | list of paths | `[]` | dotenv files, resolved relative to the task config YAML. Inline `envs` win. |
+| `secrets` | list of single-key maps | `[]` | Legacy format → `secrets[].valueFrom`. |
+| `secrets_envs` | list | `[]` | Grouped format. Ignored when a non-empty `secrets` is also set — same rule as the app. |
+| `secret_files` | list of secret names | `[]` | Generates a private init container and volume. See [Secret files](#secret-files). |
+| `secrets_files_path` | string | `/etc/secrets` | Where this sidecar's secret files are mounted. |
+| `writable_dirs` | list of paths | `[]` | Generates an empty volume per path and mounts it. |
+| `health_check` | map | — | `command`, `interval`, `timeout`, `retries`, `start_period`. Same shape as the app's. |
+| `linux_parameters` | map | — | Same shape and support matrix as [linux-parameters.md](./linux-parameters.md). |
+| `port` | int | — | → a `portMappings` entry named `<name>-<port>-tcp`. |
+| `additional_ports` | list of single-key maps | `[]` | → extra `portMappings`; the key is the mapping name. |
+| `app_protocol` | string | `http` | `http`, `grpc` or `tcp`. `tcp` omits `appProtocol`. |
+| `cpu` | int | — | Container-level CPU units. |
+| `memory` | int | — | Container-level hard memory limit, MiB. |
+| `memory_reservation` | int | — | Soft limit, MiB. Must not exceed `memory`. |
+| `readonly_root_filesystem` | bool | inherits | See below. |
+| `stop_timeout` | int | — | Seconds before SIGKILL. |
+| `log_stream_prefix` | string | the sidecar's `name` | CloudWatch stream prefix. |
+
+Anything else is rejected. A misspelled key fails the deploy with the offending key named, rather
+than being silently ignored — a sidecar quietly missing the secret its author thought they had
+configured is far worse than a failed build.
+
+### Logging
+
+Sidecars always use the `awslogs` driver, writing to the service log group
+`/ecs/<cluster>/<service>` with the sidecar's name as the stream prefix. They do **not** follow the
+application onto `awsfirelens` when `fluent_bit_collector` is enabled — the existing `fluent-bit`
+and `otel-collector` containers behave the same way. This is deliberate: routing a sidecar's logs
+through fluent-bit would make the sidecar's own diagnostics unavailable exactly when fluent-bit is
+the thing that is broken.
+
+## Read-only root filesystems
+
+`readonly_root_filesystem` is resolved per container:
+
+1. the sidecar's own value, if it sets one;
+2. otherwise the top-level `readonly_root_filesystem`;
+3. otherwise the key is omitted entirely.
+
+The application container, its secret-file init container, `fluent-bit` and `otel-collector`
+continue to take the top-level value exactly as before.
+
+> ⚠️ **Inheriting read-only does not inherit the writable mounts that make it survivable.**
+> A sidecar inherits `readonly_root_filesystem: true` but — by the isolation rule — receives none
+> of the application's `writable_dirs`. A container that needs scratch space must declare its own:
+>
+> ```yaml
+> readonly_root_filesystem: true
+> writable_dirs: [/tmp]          # the application's, and only the application's
+>
+> sidecars:
+>   - name: cache
+>     image: public.ecr.aws/docker/library/redis:7-alpine
+>     writable_dirs: [/tmp]      # required: the sidecar is read-only too
+> ```
+>
+> Without that second `writable_dirs`, redis starts read-only with nowhere to write. Either declare
+> the directories the sidecar needs, or set `readonly_root_filesystem: false` on it.
+
+### Read-only application + writable ECS Exec bridge
+
+The case this feature was built for. The application stays read-only with a writable `/tmp`, while
+a tiny bridge container runs writable so the ECS Exec managed agent can unpack itself:
+
+```yaml
+readonly_root_filesystem: true
+writable_dirs:
+  - /tmp
+
+port: 8080
+envs:
+  - NODE_ENV: production
+command: ["npm", "start"]
+
+sidecars:
+  - name: ssm-bridge
+    image: public.ecr.aws/amazonlinux/amazonlinux@sha256:<pinned-digest>
+    essential: true
+    command:
+      - sleep
+      - infinity
+    readonly_root_filesystem: false
+    linux_parameters:
+      init_process_enabled: true
+```
+
+The bridge gets `readonlyRootFilesystem: false`, and no application environment, secrets,
+secret-file mounts, writable directories or port mappings. Full example:
+[`examples/sidecar-readonly-bridge.yaml`](../examples/sidecar-readonly-bridge.yaml).
+
+## Environment and secrets
+
+Secrets remain ECS `valueFrom` references. They are never resolved into plaintext values in the
+task definition.
+
+```yaml
+sidecars:
+  - name: metrics
+    image: public.ecr.aws/my-org/metrics-agent:v1.4.2
+    envs:
+      - AGENT_MODE: push
+      - SCRAPE_INTERVAL: 15
+    envs_from_files:
+      - ./shared/common.env
+    secrets_envs:
+      - id: arn:aws:secretsmanager:us-east-1:123456789012:secret:metrics-abc123
+        values:
+          - REMOTE_WRITE_USER
+          - REMOTE_WRITE_PASSWORD
+    port: 9090
+    cpu: 128
+    memory: 256
+```
+
+`envs_from_files` paths resolve relative to the task config YAML, the same as at the top level, and
+only ever populate the sidecar that declares them. Full example:
+[`examples/sidecar-full-features.yaml`](../examples/sidecar-full-features.yaml).
+
+## Secret files
+
+A sidecar with `secret_files` gets its **own** init container and its **own** volume — it does not
+share the application's. The sidecar depends on that init container with condition `SUCCESS`, so it
+only starts once its files are on disk.
+
+```yaml
+sidecars:
+  - name: metrics
+    image: public.ecr.aws/my-org/metrics-agent:v1.4.2
+    secret_files:
+      - metrics-client-cert
+    secrets_files_path: /etc/metrics-secrets
+```
+
+## Reserved and generated names
+
+Generated names are prefixed with the sidecar's name, so two sidecars that both want a writable
+`/tmp` get two separate volumes rather than accidentally sharing one scratch directory:
+
+| Thing | Application | Sidecar `metrics` |
+|---|---|---|
+| secret-file init container | `init-container-for-secret-files` | `metrics-secret-init` |
+| secret-file volume | `shared-volume` | `metrics-secrets` |
+| writable `/tmp` volume | `writable-tmp` | `metrics-writable-tmp` |
+| primary port mapping | `default` | `metrics-9090-tcp` |
+
+A sidecar name may not be `app`, `fluent-bit`, `otel-collector`, `init-container-for-secret-files`
+or `default`, may not duplicate another sidecar, and may not collide with a name generated for
+another sidecar. Generated volume names must be valid ECS names (letters, digits, `-` and `_`), so
+a directory path containing other characters is rejected up front rather than at
+`RegisterTaskDefinition` time.
+
+Both port namespaces are validated too, because ECS scopes them to the whole task rather than to a
+single container:
+
+- **Port mapping names** must be unique task-wide, which is why a sidecar's primary port is not
+  called `default`. ECS also requires them to be lowercase, so a sidecar named `My_Proxy` with a
+  `port` is rejected here rather than by AWS.
+- **Container ports** must be unique task-wide under `awsvpc` and `host`, where every container
+  shares one network interface — an application on `8080` and a sidecar on `8080` cannot coexist.
+  Under `bridge` the host port is assigned dynamically, so duplicates are allowed.
+
+## Per-service overrides
+
+Under `services_overrides`, sidecars merge **by name** rather than being appended — otherwise a
+service override would produce two containers with the same name, which ECS rejects.
+
+For a matched name, the usual override rules apply inside the sidecar: scalars replace, arrays
+extend, maps replace wholesale, and an explicit `null` deletes the key. A name not present in the
+base list is appended.
+
+```yaml
+sidecars:
+  - name: ssm-bridge
+    image: public.ecr.aws/amazonlinux/amazonlinux:2023
+    command: ["sleep", "infinity"]
+    readonly_root_filesystem: false
+
+  - name: cache
+    image: public.ecr.aws/docker/library/redis:7-alpine
+    memory_reservation: 64
+    envs:
+      - REDIS_MAXMEMORY: 32mb
+
+services_overrides:
+  worker-service:
+    sidecars:
+      # Switched off for this service only.
+      - name: ssm-bridge
+        enabled: false
+
+      # Patched: memory_reservation replaced, REDIS_APPENDONLY appended to envs.
+      - name: cache
+        memory_reservation: 128
+        envs:
+          - REDIS_APPENDONLY: "no"
+
+      # Not in the base list, so appended for this service only.
+      - name: audit-tailer
+        image: public.ecr.aws/my-org/audit-tailer:v1
+        essential: false
+```
+
+`sidecars: null` in a service override removes every sidecar for that service.
+
+> ⚠️ **`command` and `entrypoint` extend, they do not replace.** They are array fields, so the same
+> rule that usefully appends to `envs` also appends to them — a base `command: ["sleep", "infinity"]`
+> plus an override `command: ["/bin/agent"]` yields `["sleep", "infinity", "/bin/agent"]`. This
+> matches how the top-level `command` has always merged. To give a service a genuinely different
+> command, declare it as a separate sidecar (disable the base one with `enabled: false` and add
+> yours under a new name) rather than trying to override the array in place.
+
+A disabled sidecar is still validated — it is a base-config entry that will be switched back on one
+day — but it contributes no containers, volumes or names to the task definition.
+
+Full example:
+[`examples/sidecar-service-overrides.yaml`](../examples/sidecar-service-overrides.yaml).
+
+## Examples
+
+| File | Shows |
+|---|---|
+| [`sidecar-minimal.yaml`](../examples/sidecar-minimal.yaml) | The smallest possible sidecar |
+| [`sidecar-readonly-bridge.yaml`](../examples/sidecar-readonly-bridge.yaml) | Read-only app + writable ECS Exec bridge |
+| [`sidecar-full-features.yaml`](../examples/sidecar-full-features.yaml) | Every supported key on one sidecar |
+| [`sidecar-two-writable-tmp.yaml`](../examples/sidecar-two-writable-tmp.yaml) | Two sidecars sharing a path, separate volumes |
+| [`sidecar-service-overrides.yaml`](../examples/sidecar-service-overrides.yaml) | Per-service patch, disable and add |

--- a/examples/sidecar-full-features.yaml
+++ b/examples/sidecar-full-features.yaml
@@ -1,0 +1,77 @@
+# Sidecar Using Every Supported Feature
+#
+# One sidecar exercising the whole schema: env values (inline and from a dotenv
+# file), ECS secret references, secret files (which generate their own init
+# container and volume), writable directories, a health check, linux parameters,
+# ports, container-level reservations and a custom log stream prefix.
+#
+# The application container is configured with a different set of everything, to
+# make the isolation obvious: nothing crosses between the two.
+name: sidecar-full-features-app
+replica_count: 1
+cpu: 1024
+memory: 2048
+role_arn: arn:aws:iam::123456789012:role/ecsTaskExecutionRole
+
+port: 8080
+envs:
+  - NODE_ENV: production
+secret_files:
+  - app-certificate
+
+sidecars:
+  - name: metrics
+    image: public.ecr.aws/my-org/metrics-agent:v1.4.2
+    essential: false
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["exec /usr/bin/metrics-agent --listen :9090"]
+    stop_timeout: 5
+
+    envs:
+      - AGENT_MODE: push
+      - SCRAPE_INTERVAL: 15
+    envs_from_files:
+      - ./shared/common.env
+
+    # Secrets stay ECS valueFrom references - they are never resolved to
+    # plaintext in the task definition. `secrets` (legacy) and `secrets_envs`
+    # behave for a sidecar exactly as they do for the application container,
+    # including the rule that a non-empty legacy `secrets` list wins outright.
+    secrets_envs:
+      - id: arn:aws:secretsmanager:us-east-1:123456789012:secret:metrics-abc123
+        values:
+          - REMOTE_WRITE_USER
+          - REMOTE_WRITE_PASSWORD
+
+    secret_files:
+      - metrics-client-cert
+    secrets_files_path: /etc/metrics-secrets
+
+    writable_dirs:
+      - /tmp
+      - /var/run
+
+    health_check:
+      command: "wget -q -O- http://127.0.0.1:9090/-/healthy || exit 1"
+      interval: 15
+      timeout: 3
+      retries: 2
+      start_period: 20
+
+    linux_parameters:
+      init_process_enabled: true
+      capabilities:
+        drop:
+          - ALL
+
+    port: 9090
+    additional_ports:
+      - agent-admin: 9091
+    app_protocol: http
+
+    cpu: 128
+    memory: 256
+    memory_reservation: 128
+
+    readonly_root_filesystem: true
+    log_stream_prefix: metrics-agent

--- a/examples/sidecar-minimal.yaml
+++ b/examples/sidecar-minimal.yaml
@@ -1,0 +1,17 @@
+# Minimal Generic Sidecar
+# The smallest possible sidecar: a name and an image. Everything else defaults -
+# essential: true, no environment, no secrets, no mounts, no ports - and logs go
+# to the service log group under a stream prefix named after the sidecar.
+name: sidecar-minimal-app
+replica_count: 1
+cpu: 256
+memory: 512
+role_arn: arn:aws:iam::123456789012:role/ecsTaskExecutionRole
+port: 8080
+
+envs:
+  - NODE_ENV: production
+
+sidecars:
+  - name: metrics-proxy
+    image: public.ecr.aws/nginx/nginx:1.27

--- a/examples/sidecar-readonly-bridge.yaml
+++ b/examples/sidecar-readonly-bridge.yaml
@@ -1,0 +1,46 @@
+# Read-Only Application + Writable ECS Exec Bridge
+#
+# The motivating case for generic sidecars. The application container keeps
+# readonlyRootFilesystem: true (with /tmp backed by a writable volume), while a
+# tiny bridge container runs with a writable root filesystem so the ECS Exec
+# managed agent has somewhere to unpack itself.
+#
+# Note what the bridge does NOT get: none of the application's environment,
+# secrets, secret files, writable mounts or ports. A sidecar only ever receives
+# what its own block declares.
+name: readonly-with-bridge-app
+replica_count: 1
+cpu: 256
+memory: 512
+cpu_arch: ARM64
+role_arn: arn:aws:iam::123456789012:role/ecsTaskExecutionRole
+
+readonly_root_filesystem: true
+writable_dirs:
+  - /tmp
+
+port: 8080
+envs:
+  - NODE_ENV: production
+  - SECRET_PATH: /etc/secrets
+secrets:
+  - CLIENT_ID: arn:aws:secretsmanager::secret:app-production-IhUQht
+command: ["npm", "start"]
+
+sidecars:
+  - name: ssm-bridge
+    # Pin sidecar images by digest: nothing in the deploy pipeline rebuilds them.
+    image: public.ecr.aws/amazonlinux/amazonlinux@sha256:0000000000000000000000000000000000000000000000000000000000000000
+    essential: true
+    command:
+      - sleep
+      - infinity
+    # Overrides the top-level `true` for this container only.
+    readonly_root_filesystem: false
+    linux_parameters:
+      init_process_enabled: true
+    envs: []
+    secrets: []
+    secrets_envs: []
+    secret_files: []
+    writable_dirs: []

--- a/examples/sidecar-service-overrides.yaml
+++ b/examples/sidecar-service-overrides.yaml
@@ -1,0 +1,47 @@
+# Per-Service Sidecar Overrides
+#
+# Sidecars merge by name rather than being appended, so a service can patch a
+# base sidecar, switch one off entirely, or add one of its own.
+#
+# For `test-service` (the name the test runner deploys as) the result is:
+#   - ssm-bridge  : disabled, absent from the task definition
+#   - cache       : patched - bigger reservation, one extra env var appended
+#   - audit-tailer: added, exists only for this service
+cpu: 512
+memory: 1024
+role_arn: arn:aws:iam::123456789012:role/ecsTaskExecutionRole
+port: 8080
+
+envs:
+  - LOG_LEVEL: info
+
+sidecars:
+  - name: ssm-bridge
+    image: public.ecr.aws/amazonlinux/amazonlinux:2023
+    command: ["sleep", "infinity"]
+    readonly_root_filesystem: false
+
+  - name: cache
+    image: public.ecr.aws/docker/library/redis:7-alpine
+    memory_reservation: 64
+    envs:
+      - REDIS_MAXMEMORY: 32mb
+
+services_overrides:
+  test-service:
+    sidecars:
+      # Matched by name: switched off for this service only.
+      - name: ssm-bridge
+        enabled: false
+
+      # Matched by name: scalars replace, arrays extend - so the base
+      # REDIS_MAXMEMORY entry is kept and REDIS_APPENDONLY is appended.
+      - name: cache
+        memory_reservation: 128
+        envs:
+          - REDIS_APPENDONLY: "no"
+
+      # Not in the base list: appended.
+      - name: audit-tailer
+        image: public.ecr.aws/my-org/audit-tailer:v1
+        essential: false

--- a/examples/sidecar-two-writable-tmp.yaml
+++ b/examples/sidecar-two-writable-tmp.yaml
@@ -1,0 +1,34 @@
+# Two Sidecars Sharing a Directory Path
+#
+# Both sidecars want a writable /tmp, and so does the application. Because every
+# generated volume name is prefixed with its owner, they get three separate
+# volumes - writable-tmp, cache-writable-tmp and shipper-writable-tmp - rather
+# than accidentally sharing one scratch directory.
+name: two-writable-tmp-app
+replica_count: 1
+cpu: 512
+memory: 1024
+role_arn: arn:aws:iam::123456789012:role/ecsTaskExecutionRole
+
+readonly_root_filesystem: true
+writable_dirs:
+  - /tmp
+
+port: 8080
+
+sidecars:
+  - name: cache
+    image: public.ecr.aws/docker/library/redis:7-alpine
+    writable_dirs:
+      - /tmp
+
+  - name: shipper
+    image: public.ecr.aws/my-org/log-shipper:v2
+    # Inherits readonly_root_filesystem: true from the top level - only the
+    # explicit per-sidecar value overrides it.
+    writable_dirs:
+      - /tmp
+    # The legacy `secrets` format works for sidecars too, and stays a valueFrom
+    # reference. The application container declares none of these.
+    secrets:
+      - SHIPPER_TOKEN: arn:aws:secretsmanager::secret:log-shipper-token-XyZ123

--- a/scripts/generate_readme_docs.py
+++ b/scripts/generate_readme_docs.py
@@ -116,6 +116,56 @@ def infer_field_types_and_examples():
         
         # Secret files
         'secret_files': ['ssl-certificate', 'private-key', 'config-file'],
+
+        # Launch type, networking and container flags. Every field below is
+        # discovered from generate_task_def.py but has no curated example, so it
+        # used to fall through to a placeholder string like
+        # 'example-launch-type' - which failed validation and made every run of
+        # this script emit "# Error generating task definition" instead of a
+        # task definition.
+        'launch_type': 'FARGATE',
+        'network_mode': 'awsvpc',
+        'app_protocol': 'http',
+        'stop_timeout': 30,
+        'ephemeral_storage': 21,
+        'readonly_root_filesystem': True,
+        'writable_dirs': ['/tmp', '/var/run'],
+        'secrets_files_path': '/etc/secrets',
+        'linux_parameters': {
+            'init_process_enabled': True,
+            'capabilities': {'drop': ['ALL']},
+        },
+
+        # Per-service overrides. Like sidecars below, this is discovered from
+        # generate_task_def.py and needs a real value - the inferred string made
+        # every run of this script emit "# Error generating task definition".
+        'services_overrides': {
+            'worker-service': {
+                'cpu': 512,
+                'memory': 1024,
+                'envs': [{'WORKER_MODE': 'true'}],
+            }
+        },
+
+        # Generic sidecars. Needs a real value here: without one the field is
+        # discovered from generate_task_def.py but falls through to the string
+        # 'example-sidecars', which then fails validation and blanks out the
+        # generated task definition below.
+        'sidecars': [
+            {
+                'name': 'metrics-agent',
+                'image': 'public.ecr.aws/my-org/metrics-agent:v1.4.2',
+                'essential': False,
+                # Not 9090: additional_ports above already claims that port for
+                # the app, and under awsvpc all containers share one interface.
+                'port': 9464,
+                'cpu': 128,
+                'memory': 256,
+                'envs': [{'AGENT_MODE': 'push'}],
+                'writable_dirs': ['/tmp'],
+                'readonly_root_filesystem': True,
+            }
+        ],
         
         # OpenTelemetry
         'otel_collector': {
@@ -158,6 +208,11 @@ def create_comprehensive_yaml():
         'name'  # Only used as fallback when service_name is not provided, but service_name is always provided by the action
     }
     
+    # role_arn is read through a variable key (normalize_role_value), so the AST
+    # scan above cannot see it. Without it the example config has no role at all
+    # and generation fails trying to reach SSM for one.
+    discovered_fields.setdefault('role_arn', None)
+
     print(f"🔍 Discovered {len(discovered_fields)} configuration fields from generate_task_def.py")
     
     # Create comprehensive example

--- a/scripts/generate_task_def.py
+++ b/scripts/generate_task_def.py
@@ -148,6 +148,8 @@ def validate_config(config: Dict[str, Any]) -> None:
             continue
         validate_role_arn(value, f"YAML key '{key}'")
 
+    validate_sidecars(config)
+
 # Fields that are arrays and should be extended (appended) during merge
 ARRAY_FIELDS = {
     'command', 'entrypoint', 'envs', 'envs_from_files', 'secrets', 'secrets_envs',
@@ -159,6 +161,40 @@ OBJECT_FIELDS = {
     'health_check', 'linux_parameters', 'otel_collector', 'fluent_bit_collector'
 }
 
+def merge_sidecars(base_sidecars: Any, override_sidecars: Any) -> Any:
+    """Merge two `sidecars` lists by container name rather than appending.
+
+    Blindly extending (the rule for every other array field) would produce two
+    containers with the same name, which ECS rejects. Instead a service override
+    that names an existing sidecar patches it - recursively, so the array/object/
+    null rules of merge_configs apply inside the sidecar too - and a name not in
+    the base is appended. Base order is preserved.
+    """
+    if not isinstance(base_sidecars, list) or not isinstance(override_sidecars, list):
+        # Malformed input: let validate_sidecars report it with a good message.
+        return override_sidecars
+
+    merged = [dict(s) if isinstance(s, dict) else s for s in base_sidecars]
+    index = {
+        s['name']: i for i, s in enumerate(merged)
+        if isinstance(s, dict) and isinstance(s.get('name'), str)
+    }
+
+    for override in override_sidecars:
+        if not isinstance(override, dict):
+            merged.append(override)
+            continue
+        name = override.get('name')
+        position = index.get(name) if isinstance(name, str) else None
+        if position is None:
+            merged.append(dict(override))
+            if isinstance(name, str):
+                index[name] = len(merged) - 1
+            continue
+        merged[position] = merge_configs(merged[position], override)
+
+    return merged
+
 def merge_configs(base_config: Dict[str, Any], service_override: Dict[str, Any]) -> Dict[str, Any]:
     """
     Merge base configuration with service-specific overrides.
@@ -166,6 +202,7 @@ def merge_configs(base_config: Dict[str, Any], service_override: Dict[str, Any])
     - Scalars: Override replaces base
     - Arrays: Service values appended to base (extend)
     - Objects: Service object completely replaces base (shallow merge)
+    - sidecars: Merged by name (see merge_sidecars)
     """
     # Start with a copy of base config (excluding services_overrides)
     merged = {k: v for k, v in base_config.items() if k != 'services_overrides'}
@@ -176,7 +213,9 @@ def merge_configs(base_config: Dict[str, Any], service_override: Dict[str, Any])
             merged.pop(key, None)
             continue
 
-        if key in ARRAY_FIELDS:
+        if key == 'sidecars':
+            merged[key] = merge_sidecars(merged.get(key, []), override_value)
+        elif key in ARRAY_FIELDS:
             # Extend: append service array to base array
             base_array = merged.get(key, [])
             if isinstance(base_array, list) and isinstance(override_value, list):
@@ -239,6 +278,386 @@ def validate_services_overrides(config: Dict[str, Any]) -> None:
                 f"got {type(overrides).__name__}"
             )
 
+# ---------------------------------------------------------------------------
+# Generic sidecars
+# ---------------------------------------------------------------------------
+
+# ECS container and volume names share this shape: up to 255 letters, numbers,
+# hyphens and underscores. Enforced here so a bad sidecar name fails with a
+# clear message instead of an opaque RegisterTaskDefinition rejection.
+ECS_NAME_PATTERN = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_-]{0,254}$')
+
+# Port mapping names are stricter than container names: lowercase only, and
+# capped at 64 characters.
+ECS_PORT_NAME_PATTERN = re.compile(r'^[a-z][a-z0-9_-]{0,63}$')
+
+# Container names this generator produces itself. A sidecar may not take one.
+# 'default' is reserved too: build_log_configuration rewrites that stream prefix
+# to '/default' for backwards compatibility, so a sidecar named 'default' would
+# silently log into the application's stream.
+RESERVED_CONTAINER_NAMES = frozenset({
+    'app', 'init-container-for-secret-files', 'fluent-bit', 'otel-collector', 'default',
+})
+
+def _is_positive_int(value: Any) -> bool:
+    # bool is an int subclass in Python, so `port: true` must not pass as a port.
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+# Every key a sidecar block may set, mapped to its type rule. This table is the
+# single source of truth: the allowed-key set is derived from it below, so a new
+# key cannot be accepted without also being type-checked, or type-checked while
+# still being rejected as unsupported.
+SIDECAR_KEY_TYPES: Dict[str, tuple] = {
+    key: (lambda v: isinstance(v, list), "a list")
+    for key in ('command', 'entrypoint', 'envs', 'envs_from_files', 'secrets',
+                'secrets_envs', 'secret_files', 'writable_dirs', 'additional_ports')
+}
+SIDECAR_KEY_TYPES.update({
+    key: (lambda v: isinstance(v, dict), "a mapping")
+    for key in ('health_check', 'linux_parameters')
+})
+SIDECAR_KEY_TYPES.update({
+    key: (lambda v: isinstance(v, str), "a string")
+    for key in ('name', 'image', 'secrets_files_path', 'app_protocol',
+                'log_stream_prefix')
+})
+SIDECAR_KEY_TYPES.update({
+    key: (lambda v: isinstance(v, bool), "true or false")
+    for key in ('enabled', 'essential', 'readonly_root_filesystem')
+})
+SIDECAR_KEY_TYPES.update({
+    key: (_is_positive_int, "a positive integer")
+    for key in ('port', 'cpu', 'memory', 'memory_reservation', 'stop_timeout')
+})
+
+# Anything outside the table is a typo and is rejected - silently ignoring an
+# unknown key is how a sidecar ends up missing the secret or mount its author
+# thought they had configured.
+SIDECAR_ALLOWED_KEYS = frozenset(SIDECAR_KEY_TYPES)
+
+def volume_name_for_writable_dir(dir_path: str, prefix: str = "") -> str:
+    """Generate the volume name backing a writable directory.
+
+    `/var/run` becomes `writable-var-run`, or `<prefix>-writable-var-run` for a
+    sidecar. The prefix is what keeps two sidecars that both want /tmp on two
+    distinct volumes.
+    """
+    # Deliberately not str()-coerced: a non-string path raises here exactly as it
+    # did before this helper existed, rather than silently producing a volume
+    # named after an integer and a containerPath ECS will reject.
+    suffix = "writable-" + dir_path.strip("/").replace("/", "-")
+    return f"{prefix}-{suffix}" if prefix else suffix
+
+def sidecar_init_container_name(sidecar_name: str) -> str:
+    """Name of the secret-file init container generated for a sidecar."""
+    return f"{sidecar_name}-secret-init"
+
+def sidecar_secrets_volume_name(sidecar_name: str) -> str:
+    """Name of the volume carrying a sidecar's downloaded secret files."""
+    return f"{sidecar_name}-secrets"
+
+def sidecar_is_enabled(sidecar: Dict[str, Any]) -> bool:
+    """Whether a sidecar block should be rendered.
+
+    Only an explicit `enabled: false` switches one off. A missing key and a YAML
+    null both mean enabled - `enabled:` with nothing after it parses as None,
+    and silently dropping a container for that would be a nasty surprise.
+    """
+    return sidecar.get('enabled') is not False
+
+def enabled_sidecars(config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """The sidecar blocks that should actually be rendered, in declaration order."""
+    return [s for s in (config.get('sidecars') or []) if sidecar_is_enabled(s)]
+
+def _validate_sidecar_types(sidecar: Dict[str, Any], label: str) -> None:
+    """Type-check the supported keys of one sidecar block."""
+    for key, value in sidecar.items():
+        if value is None:
+            continue  # An explicit null means "unset"; treated as absent.
+        rule = SIDECAR_KEY_TYPES.get(key)
+        if rule is None:
+            continue  # Unknown keys are already rejected by the caller.
+        matches, expected = rule
+        if not matches(value):
+            # A wrong-typed value is usually best described by its type, but for
+            # a rejected number the value itself is what the author needs to see.
+            got = repr(value) if expected == "a positive integer" else type(value).__name__
+            raise ValidationError(f"{label}: '{key}' must be {expected}, got {got}")
+
+    memory = sidecar.get('memory')
+    reservation = sidecar.get('memory_reservation')
+    if memory is not None and reservation is not None and reservation > memory:
+        raise ValidationError(
+            f"{label}: memory_reservation ({reservation}) must not exceed "
+            f"memory ({memory}) - ECS rejects a soft limit above the hard limit."
+        )
+
+def validate_sidecars(config: Dict[str, Any]) -> None:
+    """Validate the `sidecars` block.
+
+    Pure and idempotent: called once early (before anything iterates sidecars,
+    so a malformed block fails with a real message rather than an AttributeError)
+    and again from validate_config, so callers that build a config dict by hand
+    are validated too.
+    """
+    sidecars = config.get('sidecars')
+    if sidecars is None:
+        return
+
+    if not isinstance(sidecars, list):
+        raise ValidationError(
+            f"sidecars must be a list of mappings, got {type(sidecars).__name__}"
+        )
+
+    # Names the finished task definition will contain, so a declared name that
+    # collides with a *generated* one is caught too.
+    container_names: Dict[str, str] = {}
+    for name in RESERVED_CONTAINER_NAMES:
+        container_names[name] = "reserved by the action"
+
+    volume_names: Dict[str, str] = {}
+    for index, sidecar in enumerate(sidecars):
+        label = f"sidecars[{index}]"
+        if not isinstance(sidecar, dict):
+            raise ValidationError(
+                f"{label} must be a mapping, got {type(sidecar).__name__}"
+            )
+
+        unknown = sorted(set(sidecar) - SIDECAR_ALLOWED_KEYS)
+        if unknown:
+            raise ValidationError(
+                f"{label}: unsupported key(s) {unknown}. Supported keys: "
+                f"{sorted(SIDECAR_ALLOWED_KEYS)}"
+            )
+
+        name = sidecar.get('name')
+        if not name or not isinstance(name, str):
+            raise ValidationError(f"{label}: 'name' is required and must be a string")
+        label = f"sidecars[{index}] ('{name}')"
+
+        if not ECS_NAME_PATTERN.match(name):
+            raise ValidationError(
+                f"{label}: invalid container name. Must start with a letter or digit "
+                f"and contain only letters, digits, '-' and '_' (max 255 characters)."
+            )
+
+        image = sidecar.get('image')
+        if not image or not isinstance(image, str):
+            raise ValidationError(f"{label}: 'image' is required and must be a string")
+
+        _validate_sidecar_types(sidecar, label)
+
+        for entry in sidecar.get('envs') or []:
+            if not isinstance(entry, dict):
+                raise ValidationError(
+                    f"{label}: envs entries must be single-key mappings of name to "
+                    f"value, got {entry!r}"
+                )
+
+        # `default` is what build_log_configuration rewrites to the application's
+        # '/default' stream, so allowing it here would reopen the collision the
+        # reserved container name closes.
+        if sidecar.get('log_stream_prefix') == 'default':
+            raise ValidationError(
+                f"{label}: log_stream_prefix 'default' is reserved for the "
+                f"application container's log stream."
+            )
+
+        # A disabled sidecar still has to be well-formed - it is a base-config
+        # entry a service switched off, and it will be switched back on one day -
+        # but it contributes no names to the task definition.
+        if not sidecar_is_enabled(sidecar):
+            continue
+
+        generated = [(name, f"declared by {label}")]
+        if sidecar.get('secret_files'):
+            generated.append((
+                sidecar_init_container_name(name),
+                f"init container generated for {label}",
+            ))
+        for candidate, origin in generated:
+            if not ECS_NAME_PATTERN.match(candidate):
+                raise ValidationError(
+                    f"{label}: generated container name '{candidate}' ({origin}) is "
+                    f"not a valid ECS container name - the sidecar name is too long."
+                )
+            clash = container_names.get(candidate)
+            if clash:
+                raise ValidationError(
+                    f"Duplicate container name '{candidate}': {origin} but it is "
+                    f"already {clash}."
+                )
+            container_names[candidate] = origin
+
+        candidates = []
+        if sidecar.get('secret_files'):
+            candidates.append((sidecar_secrets_volume_name(name), 'secret_files'))
+        for dir_path in sidecar.get('writable_dirs') or []:
+            if not isinstance(dir_path, str) or not dir_path.strip('/'):
+                raise ValidationError(
+                    f"{label}: writable_dirs entries must be non-empty absolute "
+                    f"paths, got {dir_path!r}"
+                )
+            candidates.append((volume_name_for_writable_dir(dir_path, name), dir_path))
+
+        for volume, origin in candidates:
+            if not ECS_NAME_PATTERN.match(volume):
+                raise ValidationError(
+                    f"{label}: generated volume name '{volume}' (from {origin}) is not "
+                    f"a valid ECS volume name. Use only letters, digits, '-' and '_' "
+                    f"in the sidecar name and directory path."
+                )
+            clash = volume_names.get(volume)
+            if clash:
+                raise ValidationError(
+                    f"{label}: generated volume name '{volume}' (from {origin}) "
+                    f"collides with the volume generated from {clash}."
+                )
+            volume_names[volume] = f"{label} {origin}"
+
+    # Sidecar volumes must not collide with the application's own volumes.
+    app_volumes = {'shared-volume'} if config.get('secret_files') else set()
+    app_volumes.update(
+        volume_name_for_writable_dir(d) for d in (config.get('writable_dirs') or [])
+        if isinstance(d, str)
+    )
+    for volume in sorted(volume_names.keys() & app_volumes):
+        raise ValidationError(
+            f"Generated volume name '{volume}' from {volume_names[volume]} collides "
+            f"with an application-level volume of the same name."
+        )
+
+    # Port mapping names are unique per task definition, not per container.
+    _validate_port_mapping_names(config, sidecars)
+
+    _validate_sidecar_resource_budget(config, sidecars)
+
+def _validate_sidecar_resource_budget(config: Dict[str, Any],
+                                      sidecars: List[Dict[str, Any]]) -> None:
+    """Keep container-level reservations inside the task's Fargate budget.
+
+    On Fargate, ECS rejects a task whose containers reserve more CPU or memory
+    than the task itself. Catching it here turns a mid-deploy
+    RegisterTaskDefinition failure into a config error. EC2 task-level values are
+    advisory, so the check does not apply there.
+    """
+    if config.get('launch_type', 'FARGATE').upper() != 'FARGATE':
+        return
+
+    enabled = [s for s in sidecars if isinstance(s, dict) and sidecar_is_enabled(s)]
+
+    for yaml_key, task_default, unit in (('cpu', 256, 'CPU units'),
+                                         ('memory', 512, 'MiB')):
+        task_total = config.get(yaml_key, task_default)
+        if not isinstance(task_total, int):
+            continue  # validate_config reports a bad task-level value.
+
+        claimed = [(s['name'], s[yaml_key]) for s in enabled
+                   if isinstance(s.get(yaml_key), int)]
+        reserved = sum(value for _, value in claimed)
+        if not claimed or reserved < task_total:
+            continue
+
+        breakdown = ', '.join(f"{name}={value}" for name, value in claimed)
+        raise ValidationError(
+            f"Sidecars reserve {reserved} {unit} ({breakdown}) but the task only "
+            f"has {task_total}. Container-level {yaml_key} must leave room for the "
+            f"application container - raise the task-level '{yaml_key}' or lower "
+            f"the sidecar reservations."
+        )
+
+def _sidecar_main_port_name(sidecar_name: str, port: int) -> str:
+    """Port-mapping name for a sidecar's primary port.
+
+    Mirrors the `otel-collector-4317-tcp` convention already used for the OTEL
+    container. It cannot be "default" - that name is taken by the application's
+    port and ECS requires port-mapping names to be unique across the whole task.
+    """
+    return f"{sidecar_name}-{port}-tcp"
+
+def _validate_port_mapping_names(config: Dict[str, Any], sidecars: List[Dict[str, Any]]) -> None:
+    """Reject port mapping names and container ports a sidecar would duplicate.
+
+    Both namespaces are scoped to the whole task definition rather than to one
+    container, so a sidecar can collide with the application, with the OTEL
+    collector, or with another sidecar. Only collisions *involving a sidecar*
+    are reported: a config whose own additional_ports already repeat a name
+    predates this feature and is not this change's business to start failing.
+    """
+    seen: Dict[str, str] = {}
+    # Under awsvpc and host every container shares one network namespace, so two
+    # containers cannot listen on the same port. Under bridge, hostPort 0 lets
+    # Docker assign a free one, so duplicates are fine.
+    exclusive_ports = config.get('network_mode', 'awsvpc').lower() in ('awsvpc', 'host')
+    ports_seen: Dict[int, str] = {}
+
+    def record(port_name: Any, port: Any, origin: str) -> None:
+        seen.setdefault(str(port_name), origin)
+        if isinstance(port, int):
+            ports_seen.setdefault(port, origin)
+
+    def claim(port_name: Any, port: Any, origin: str) -> None:
+        key = str(port_name)
+        clash = seen.get(key)
+        if clash:
+            raise ValidationError(
+                f"Duplicate port mapping name '{key}': used by {origin} and by "
+                f"{clash}. ECS requires port mapping names to be unique across the "
+                f"whole task definition."
+            )
+        if not ECS_PORT_NAME_PATTERN.match(key):
+            raise ValidationError(
+                f"Invalid port mapping name '{key}' from {origin}. ECS port mapping "
+                f"names must start with a lowercase letter and contain only "
+                f"lowercase letters, digits, '-' and '_' (max 64 characters)."
+            )
+        seen[key] = origin
+
+        if not isinstance(port, int) or not exclusive_ports:
+            return
+        port_clash = ports_seen.get(port)
+        if port_clash:
+            raise ValidationError(
+                f"Duplicate container port {port}: used by {origin} and by "
+                f"{port_clash}. With network_mode "
+                f"'{config.get('network_mode', 'awsvpc')}' every container shares one "
+                f"network interface, so two containers cannot listen on the same port."
+            )
+        ports_seen[port] = origin
+
+    if config.get('port'):
+        record('default', config.get('port'), "the application's 'port'")
+    for entry in config.get('additional_ports') or []:
+        if isinstance(entry, dict):
+            for port_name, port in entry.items():
+                record(port_name, port, "the application's 'additional_ports'")
+
+    # The OTEL collector hardcodes these two mappings when it is enabled.
+    if config.get('otel_collector') is not None:
+        record('otel-collector-4317-tcp', 4317, "the otel-collector")
+        record('otel-collector-4318-tcp', 4318, "the otel-collector")
+
+    for sidecar in sidecars:
+        if not isinstance(sidecar, dict) or not sidecar_is_enabled(sidecar):
+            continue
+        name = sidecar.get('name')
+        port = sidecar.get('port')
+        if port:
+            claim(_sidecar_main_port_name(name, port), port, f"sidecar '{name}' 'port'")
+        for entry in sidecar.get('additional_ports') or []:
+            if not isinstance(entry, dict):
+                raise ValidationError(
+                    f"sidecar '{name}': additional_ports entries must be mappings of "
+                    f"name to port, got {entry!r}"
+                )
+            for port_name, entry_port in entry.items():
+                if not _is_positive_int(entry_port):
+                    raise ValidationError(
+                        f"sidecar '{name}': additional_ports port for '{port_name}' "
+                        f"must be a positive integer, got {entry_port!r}"
+                    )
+                claim(port_name, entry_port, f"sidecar '{name}' 'additional_ports'")
+
 DOTENV_KEY_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
 
 def parse_dotenv_file(path: Path) -> Dict[str, str]:
@@ -270,10 +689,14 @@ def parse_dotenv_file(path: Path) -> Dict[str, str]:
             result[key] = value
     return result
 
-def expand_envs_from_files(config: Dict[str, Any], yaml_path: Path) -> None:
+def expand_envs_from_files(config: Dict[str, Any], yaml_path: Path,
+                           label: str = "the task config") -> None:
     """Resolve envs_from_files paths relative to the YAML, then merge entries
     into config['envs']. File-derived values are overridden by inline envs;
-    later files in the list override earlier ones. Mutates config in place."""
+    later files in the list override earlier ones. Mutates config in place.
+
+    Also used per sidecar, hence `label` - it only distinguishes the log line.
+    """
     file_refs = config.pop('envs_from_files', None)
     if not file_refs:
         return
@@ -306,7 +729,8 @@ def expand_envs_from_files(config: Dict[str, Any], yaml_path: Path) -> None:
 
     config['envs'] = [{k: v} for k, v in merged.items()]
     logger.info(
-        f"Loaded {file_key_count} env var(s) from {file_count} file(s) referenced by envs_from_files"
+        f"Loaded {file_key_count} env var(s) from {file_count} file(s) referenced by "
+        f"envs_from_files in {label}"
     )
 
 def load_and_validate_config(yaml_file_path: str, service_name: Optional[str] = None) -> Dict[str, Any]:
@@ -328,10 +752,20 @@ def load_and_validate_config(yaml_file_path: str, service_name: Optional[str] = 
         # Apply service-specific overrides if present
         config = apply_service_overrides(raw_config, service_name)
 
+        # Shape-check sidecars before anything iterates them, so `sidecars: oops`
+        # fails with a real message instead of an AttributeError below.
+        validate_sidecars(config)
+
         # Expand envs_from_files into the envs list (after merge so per-service
         # entries are appended; before validation so the final envs list is what
-        # validate_config sees).
+        # validate_config sees). Sidecars resolve their files against the same
+        # YAML directory, but only into their own envs.
         expand_envs_from_files(config, yaml_path)
+        # Only the sidecars that will actually be rendered: a switched-off base
+        # sidecar must not fail every deploy because its dotenv file was deleted
+        # along with it.
+        for sidecar in enabled_sidecars(config):
+            expand_envs_from_files(sidecar, yaml_path, label=f"sidecar '{sidecar.get('name')}'")
 
         # Validate the final merged config
         validate_config(config)
@@ -368,16 +802,20 @@ class ContainerBuilder:
             }
         }
     
-    def build_port_mappings(self, main_port: Optional[int], 
+    def build_port_mappings(self, main_port: Optional[int],
                            additional_ports: List[Dict[str, int]], app_protocol: str = "http",
-                           network_mode: str = "awsvpc") -> List[Dict[str, Any]]:
+                           network_mode: str = "awsvpc",
+                           main_port_name: str = "default") -> List[Dict[str, Any]]:
         """Build port mappings configuration
-        
+
         Args:
             main_port: Primary container port
             additional_ports: List of additional port mappings
             app_protocol: Application protocol (http, grpc, tcp)
             network_mode: Network mode (awsvpc, bridge, host, none)
+            main_port_name: Name of the primary port mapping. Port mapping names
+                must be unique across the whole task definition, so a sidecar
+                cannot reuse the application's "default".
         """
         port_mappings = []
         
@@ -387,7 +825,7 @@ class ContainerBuilder:
         
         if main_port:
             port_mapping = {
-                "name": "default",
+                "name": main_port_name,
                 "containerPort": main_port,
                 "hostPort": 0 if use_dynamic_host_port else main_port,
                 "protocol": "tcp"
@@ -725,7 +1163,7 @@ class SecretManager:
         secrets = []
         
         # Legacy format support
-        secret_list = config.get('secrets', [])
+        secret_list = config.get('secrets') or []
         if secret_list:
             for secret_dict in secret_list:
                 for key, base_arn in secret_dict.items():
@@ -737,7 +1175,7 @@ class SecretManager:
             return secrets
         
         # New format
-        secrets_envs = config.get('secrets_envs', [])
+        secrets_envs = config.get('secrets_envs') or []
         
         for secret_config in secrets_envs:
             secret_id = secret_config.get('id', '')
@@ -811,8 +1249,52 @@ def build_image_uri(container_registry: Optional[str], image_name: str, tag: str
     logger.info(f"Container image URI: {image_uri}")
     return image_uri
 
-def build_init_containers(config, secret_files, cluster_name, app_name, aws_region, secrets_files_path="/etc/secrets"):
-    """Build init containers for secret file downloads"""
+def build_environment(container_config: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Build the `environment` list from a container's `envs` block.
+
+    Shared by the application container and every generic sidecar. Values are
+    stringified because ECS only accepts strings, so `ENABLE_METRICS: true`
+    becomes "True" - long-standing behaviour that existing goldens assert.
+    """
+    environment = []
+    for env_var in container_config.get('envs') or []:
+        for key, value in env_var.items():
+            environment.append({
+                "name": key,
+                "value": str(value)
+            })
+    return environment
+
+def build_health_check(container_config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Build a container `healthCheck` from a `health_check` block, or None.
+
+    Shared by the application container and every generic sidecar. A block with
+    no (or an empty) command yields no healthCheck at all rather than a broken
+    one.
+    """
+    health_check = container_config.get('health_check', {})
+    if not health_check or not health_check.get('command'):
+        return None
+
+    return {
+        "command": ["CMD-SHELL", health_check["command"]],
+        "interval": health_check.get('interval', 30),
+        "timeout": health_check.get('timeout', 5),
+        "retries": health_check.get('retries', 3),
+        "startPeriod": health_check.get('start_period', 10)
+    }
+
+def build_init_containers(config, secret_files, cluster_name, app_name, aws_region,
+                          secrets_files_path="/etc/secrets", *,
+                          container_name="init-container-for-secret-files",
+                          source_volume="shared-volume",
+                          log_stream_prefix="ssm-file-downloader"):
+    """Build init containers for secret file downloads
+
+    The keyword-only arguments default to the application's long-standing names.
+    Sidecars pass their own prefixed names so two containers that both want
+    secret files do not fight over one container name and one volume.
+    """
     container_definitions = []
     
     # Handle secret files (existing functionality)
@@ -823,7 +1305,7 @@ def build_init_containers(config, secret_files, cluster_name, app_name, aws_regi
         container_builder = ContainerBuilder(cluster_name, app_name, aws_region)
         
         init_container = {
-            "name": "init-container-for-secret-files",
+            "name": container_name,
             "image": "public.ecr.aws/aws-cli/aws-cli:latest",
             "essential": False,
             "entryPoint": ["/bin/sh"],
@@ -864,14 +1346,14 @@ def build_init_containers(config, secret_files, cluster_name, app_name, aws_regi
             ],
             "mountPoints": [
                 {
-                    "sourceVolume": "shared-volume",
+                    "sourceVolume": source_volume,
                     "containerPath": secrets_files_path
                 }
             ],
-            "logConfiguration": container_builder.build_log_configuration(stream_prefix="ssm-file-downloader")
+            "logConfiguration": container_builder.build_log_configuration(stream_prefix=log_stream_prefix)
         }
         container_definitions.append(init_container)
-        logger.info(f"Built init container for {len(secret_files)} secret files")
+        logger.info(f"Built init container '{container_name}' for {len(secret_files)} secret files")
     
     return container_definitions
 
@@ -1013,6 +1495,64 @@ def build_linux_parameters(config: Dict[str, Any], launch_type: str = "FARGATE")
     
     return linux_parameters if linux_parameters else None
 
+def build_container_base(spec, container_builder, *, name, image, essential,
+                         log_configuration, environment, secrets, health,
+                         network_mode="awsvpc", launch_type="FARGATE",
+                         main_port_name="default"):
+    """Build the parts of a container definition that every container shares.
+
+    `spec` is the config block that owns the container: the whole task config
+    for the application container, or a single `sidecars` entry. Everything read
+    from it - command, entrypoint, stop_timeout, ports, health check, linux
+    parameters - therefore comes from that container's own configuration, which
+    is what keeps sidecars isolated from the application.
+
+    Callers add whatever is specific to them (mount points, dependencies,
+    resource reservations, readonlyRootFilesystem) to the returned dict.
+    """
+    # `or []` rather than a .get() default throughout: a key written with no
+    # value (`command:`) parses as None, and validation treats that as "unset".
+    # Emitting `"command": null` would be rejected by RegisterTaskDefinition
+    # after every offline check had already passed.
+    container = {
+        "name": name,
+        "image": image,
+        "essential": essential,
+        "environment": environment,
+        "command": spec.get('command') or [],
+        "entryPoint": spec.get('entrypoint') or [],
+        "secrets": secrets,
+    }
+
+    # Add stopTimeout if specified
+    stop_timeout = spec.get('stop_timeout')
+    if stop_timeout is not None:
+        container["stopTimeout"] = int(stop_timeout)
+
+    container["logConfiguration"] = log_configuration
+
+    # Only include healthCheck if it was properly built
+    if health:
+        container["healthCheck"] = health
+
+    # Handle port configurations
+    port_mappings = container_builder.build_port_mappings(
+        spec.get('port'),
+        spec.get('additional_ports') or [],
+        spec.get('app_protocol') or 'http',
+        network_mode,
+        main_port_name,
+    )
+    if port_mappings:
+        container["portMappings"] = port_mappings
+
+    # Add linuxParameters if configured
+    linux_parameters = build_linux_parameters(spec, launch_type)
+    if linux_parameters:
+        container["linuxParameters"] = linux_parameters
+
+    return container
+
 def build_app_container(config, image_uri, environment, secrets, health, cluster_name, app_name, aws_region, use_fluent_bit, has_secret_files, secrets_files_path="/etc/secrets", network_mode="awsvpc", launch_type="FARGATE"):
     """
     Build the main application container definition for the ECS task.
@@ -1051,53 +1591,30 @@ def build_app_container(config, image_uri, environment, secrets, health, cluster
         A dictionary describing the main application container suitable for
         inclusion in an ECS task definition.
     """
-    command = config.get('command', [])
-    entrypoint = config.get('entrypoint', [])
-    stop_timeout = config.get('stop_timeout')
-    
     container_builder = ContainerBuilder(cluster_name, app_name, aws_region)
-    
-    app_container = {
-        "name": "app",
-        "image": image_uri,
-        "essential": True,
-        "environment": environment,
-        "command": command,
-        "entryPoint": entrypoint,
-        "secrets": secrets
-    }
-    
-    # Add stopTimeout if specified
-    if stop_timeout is not None:
-        app_container["stopTimeout"] = int(stop_timeout)
-    
+
     # Set logConfiguration for app container
     if use_fluent_bit:
-        app_container["logConfiguration"] = {
+        log_configuration = {
             "logDriver": "awsfirelens",
             "options": {}
         }
     else:
-        app_container["logConfiguration"] = container_builder.build_log_configuration(stream_prefix="default")
-    
-    # Only include healthCheck if it was properly built
-    if health:
-        app_container["healthCheck"] = health
+        log_configuration = container_builder.build_log_configuration(stream_prefix="default")
 
-    # Handle port configurations
-    main_port = config.get('port')
-    additional_ports = config.get('additional_ports', [])
-    app_protocol = config.get('app_protocol', 'http')
-    
-    port_mappings = container_builder.build_port_mappings(main_port, additional_ports, app_protocol, network_mode)
-    if port_mappings:
-        app_container["portMappings"] = port_mappings
-    
-    # Add linuxParameters if configured
-    linux_parameters = build_linux_parameters(config, launch_type)
-    if linux_parameters:
-        app_container["linuxParameters"] = linux_parameters
-    
+    app_container = build_container_base(
+        config, container_builder,
+        name="app",
+        image=image_uri,
+        essential=True,
+        log_configuration=log_configuration,
+        environment=environment,
+        secrets=secrets,
+        health=health,
+        network_mode=network_mode,
+        launch_type=launch_type,
+    )
+
     # Add mount points if using shared volume
     if has_secret_files:
         app_container["mountPoints"] = [
@@ -1263,6 +1780,124 @@ def build_otel_container(config, otel_collector_image, otel_is_custom_image, ote
     
     return otel_container
 
+def build_sidecar_container(sidecar, config, cluster_name, app_name, aws_region,
+                            network_mode="awsvpc", launch_type="FARGATE"):
+    """Build one generic sidecar, plus the init container and volumes it needs.
+
+    Isolation is the whole point: nothing from the application container leaks
+    in. A sidecar's environment, secrets, secret files, mounts, ports, health
+    check and linux parameters come exclusively from its own block. The single
+    inherited value is readonly_root_filesystem, and only as a fallback when the
+    sidecar does not state one of its own.
+
+    Args:
+        sidecar: One entry of the `sidecars` list, already validated.
+        config: The full task config, read only for the readonly_root_filesystem
+            fallback.
+
+    Returns:
+        (container_definitions, volumes). When the sidecar declares secret_files
+        its init container precedes it, so `dependsOn` is satisfiable.
+    """
+    name = sidecar['name']
+
+    if sidecar.get('envs_from_files'):
+        # Normally expanded in load_and_validate_config. Reaching here means the
+        # caller built a config dict by hand and skipped that step; silently
+        # dropping the file would ship a sidecar missing its environment.
+        raise ValidationError(
+            f"sidecar '{name}': envs_from_files was not expanded. It is only "
+            f"supported when the config is loaded from a YAML file."
+        )
+
+    builder = ContainerBuilder(cluster_name, app_name, aws_region)
+    containers = []
+    volumes = []
+
+    main_port = sidecar.get('port')
+    container = build_container_base(
+        sidecar, builder,
+        name=name,
+        image=sidecar['image'],
+        # Only an explicit `essential: false` makes a sidecar non-essential. A
+        # blank `essential:` parses as None, and bool(None) would silently mean
+        # "let this container die without failing the task".
+        essential=sidecar.get('essential') is not False,
+        # Sidecars always log straight to CloudWatch under the service log
+        # group, exactly like the fluent-bit and otel-collector containers -
+        # they do not follow the application onto awsfirelens.
+        log_configuration=builder.build_log_configuration(
+            stream_prefix=sidecar.get('log_stream_prefix', name)
+        ),
+        environment=build_environment(sidecar),
+        secrets=SecretManager.build_secrets_from_config(sidecar),
+        health=build_health_check(sidecar),
+        network_mode=network_mode,
+        launch_type=launch_type,
+        main_port_name=_sidecar_main_port_name(name, main_port) if main_port else name,
+    )
+
+    # Container-level reservations. Task-level cpu/memory are strings; the
+    # container-level equivalents must be integers.
+    for yaml_key, td_key in (('cpu', 'cpu'), ('memory', 'memory'),
+                             ('memory_reservation', 'memoryReservation')):
+        value = sidecar.get(yaml_key)
+        if value is not None:
+            container[td_key] = int(value)
+
+    # Per-container precedence: the sidecar's own value wins, otherwise the
+    # application-level default, otherwise the key is omitted entirely.
+    readonly = sidecar.get('readonly_root_filesystem')
+    if readonly is None:
+        readonly = config.get('readonly_root_filesystem')
+    if readonly is not None:
+        container["readonlyRootFilesystem"] = bool(readonly)
+
+    mount_points = []
+    depends_on = []
+
+    secret_files = sidecar.get('secret_files') or []
+    if secret_files:
+        secrets_files_path = sidecar.get('secrets_files_path', '/etc/secrets')
+        init_name = sidecar_init_container_name(name)
+        volume_name = sidecar_secrets_volume_name(name)
+
+        init_containers = build_init_containers(
+            sidecar, secret_files, cluster_name, app_name, aws_region,
+            secrets_files_path,
+            container_name=init_name,
+            source_volume=volume_name,
+            log_stream_prefix=init_name,
+        )
+        for init_container in init_containers:
+            if readonly is not None:
+                init_container["readonlyRootFilesystem"] = bool(readonly)
+        containers.extend(init_containers)
+        volumes.append({"name": volume_name, "host": {}})
+
+        mount_points.append({
+            "sourceVolume": volume_name,
+            "containerPath": secrets_files_path
+        })
+        depends_on.append({"containerName": init_name, "condition": "SUCCESS"})
+
+    for dir_path in sidecar.get('writable_dirs') or []:
+        volume_name = volume_name_for_writable_dir(dir_path, name)
+        volumes.append({"name": volume_name, "host": {}})
+        mount_points.append({
+            "sourceVolume": volume_name,
+            "containerPath": dir_path
+        })
+
+    if mount_points:
+        container["mountPoints"] = mount_points
+    if depends_on:
+        container["dependsOn"] = depends_on
+
+    containers.append(container)
+    logger.info(f"Built sidecar container '{name}'")
+    return containers, volumes
+
 def generate_task_definition(config_dict=None, yaml_file_path=None, cluster_name=None, aws_region=None, registry=None, container_registry=None, image_name=None, tag=None, service_name=None, public_image=None):
     """
     Generate an ECS task definition from a simplified YAML configuration
@@ -1288,7 +1923,12 @@ def generate_task_definition(config_dict=None, yaml_file_path=None, cluster_name
         config = load_and_validate_config(yaml_file_path, service_name)
     else:
         config = config_dict
-    
+
+    # Cheap and idempotent, and the config_dict path above never went through
+    # load_and_validate_config - without this a hand-built config could emit a
+    # task definition with duplicate container or volume names.
+    validate_sidecars(config)
+
     # Extract values from config
     # Use service name from action instead of YAML name
     app_name = service_name if service_name else config.get('name', 'app')
@@ -1317,19 +1957,8 @@ def generate_task_definition(config_dict=None, yaml_file_path=None, cluster_name
     cpu_arch = config.get('cpu_arch', 'X86_64')
     command = config.get('command', [])
     entrypoint = config.get('entrypoint', [])
-    health_check = config.get('health_check', {})
-    # Only build health check if config has values and command is non-empty
-    if health_check and health_check.get('command'):
-        health = {
-            "command": ["CMD-SHELL", health_check["command"]],
-            "interval": health_check.get('interval', 30),
-            "timeout": health_check.get('timeout', 5),
-            "retries": health_check.get('retries', 3),
-            "startPeriod": health_check.get('start_period', 10)
-        }
-    else:
-        health = None
-    
+    health = build_health_check(config)
+
     # Extract replica_count for later use in the GitHub Action
     replica_count = config.get('replica_count', '')
 
@@ -1348,14 +1977,8 @@ def generate_task_definition(config_dict=None, yaml_file_path=None, cluster_name
         fluent_bit_image = ''
     
     # Get environment variables (changed from env_variables to envs)
-    environment = []
-    for env_var in config.get('envs', []):
-        for key, value in env_var.items():
-            environment.append({
-                "name": key,
-                "value": str(value)  # Convert to string for ECS compatibility
-            })
-    
+    environment = build_environment(config)
+
     # Get secrets using the SecretManager
     secrets = SecretManager.build_secrets_from_config(config)
     
@@ -1378,7 +2001,7 @@ def generate_task_definition(config_dict=None, yaml_file_path=None, cluster_name
     writable_dirs = config.get('writable_dirs', [])
     for dir_path in writable_dirs:
         # Generate volume name from path: /tmp -> writable-tmp, /var/run -> writable-var-run
-        vol_name = "writable-" + dir_path.strip("/").replace("/", "-")
+        vol_name = volume_name_for_writable_dir(dir_path)
         volumes.append({
             "name": vol_name,
             "host": {}
@@ -1417,24 +2040,40 @@ def generate_task_definition(config_dict=None, yaml_file_path=None, cluster_name
         otel_container = build_otel_container(config, otel_collector_image, otel_is_custom_image, otel_collector_ssm, otel_extra_config, otel_metrics_port, otel_metrics_path, app_name, cluster_name, aws_region)
         container_definitions.append(otel_container)
     
-    # Apply readonlyRootFilesystem to ALL containers if specified
+    # The two passes below apply the application-level defaults to the
+    # application container and its built-in companions (init, fluent-bit,
+    # otel). Generic sidecars are deliberately appended AFTERWARDS: they are
+    # isolated by contract and manage their own readonly flag and mounts.
+    #
+    # Apply readonlyRootFilesystem to the application containers if specified
     readonly_root_filesystem = config.get('readonly_root_filesystem')
     if readonly_root_filesystem is not None:
         for container in container_definitions:
             container["readonlyRootFilesystem"] = bool(readonly_root_filesystem)
-    
-    # Add writable_dirs mountPoints to ALL containers if specified
+
+    # Add writable_dirs mountPoints to the application containers if specified
     if writable_dirs:
         for container in container_definitions:
             if "mountPoints" not in container:
                 container["mountPoints"] = []
             for dir_path in writable_dirs:
-                vol_name = "writable-" + dir_path.strip("/").replace("/", "-")
+                vol_name = volume_name_for_writable_dir(dir_path)
                 container["mountPoints"].append({
                     "sourceVolume": vol_name,
                     "containerPath": dir_path
                 })
-    
+
+    # Generic sidecars, in declaration order. Must stay below the two blanket
+    # passes above - that is what keeps a sidecar from inheriting application
+    # mounts and the application readonly flag it explicitly overrode.
+    for sidecar in enabled_sidecars(config):
+        sidecar_containers, sidecar_volumes = build_sidecar_container(
+            sidecar, config, cluster_name, app_name, aws_region,
+            network_mode, launch_type
+        )
+        container_definitions.extend(sidecar_containers)
+        volumes.extend(sidecar_volumes)
+
     # Resolve the two IAM role slots: YAML first, then the SSM parameters
     # published by terraform-aws-ecs-service. Unresolved slots are a hard error.
     # Done here, after the containers are built, so pure-config errors still

--- a/tests/expected_outputs/sidecar-full-features.json
+++ b/tests/expected_outputs/sidecar-full-features.json
@@ -1,0 +1,262 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "init-container-for-secret-files",
+      "image": "public.ecr.aws/aws-cli/aws-cli:latest",
+      "essential": false,
+      "entryPoint": [
+        "/bin/sh"
+      ],
+      "command": [
+        "-c",
+        "for secret in ${SECRET_FILES//,/ }; do   echo \"Fetching $secret...\";   echo \"Debug: AWS_REGION=$AWS_REGION, SECRET_PATH=/etc/secrets\";   SECRET_VALUE=$(aws secretsmanager get-secret-value --secret-id $secret --region $AWS_REGION --query SecretString --output text 2>/dev/null);   STRING_RESULT=$?;   if [ $STRING_RESULT -eq 0 ] && [ -n \"$SECRET_VALUE\" ] && [ \"$SECRET_VALUE\" != \"null\" ] && [ \"$SECRET_VALUE\" != \"none\" ] && [ \"$SECRET_VALUE\" != \"None\" ]; then     echo \"Found text secret, saving to /etc/secrets/$secret\";     echo \"$SECRET_VALUE\" > /etc/secrets/$secret;   else     echo \"Text retrieval failed or returned null, trying binary retrieval...\";     aws secretsmanager get-secret-value --secret-id $secret --region $AWS_REGION --query SecretBinary --output text | base64 -d > /etc/secrets/$secret 2>/dev/null;     BINARY_RESULT=$?;     if [ $BINARY_RESULT -eq 0 ] && [ -s /etc/secrets/$secret ]; then       echo \"Found binary secret, saved to /etc/secrets/$secret\";     else       echo \"\u274c Failed to retrieve $secret as either text or binary\" >&2;       echo \"Text result: $STRING_RESULT, Binary result: $BINARY_RESULT\" >&2;       exit 1;     fi;   fi;   echo \"\u2705 Successfully saved $secret to /etc/secrets/$secret (size: $(stat -c%s /etc/secrets/$secret 2>/dev/null || wc -c < /etc/secrets/$secret))\"; done"
+      ],
+      "environment": [
+        {
+          "name": "SECRET_FILES",
+          "value": "app-certificate"
+        },
+        {
+          "name": "AWS_REGION",
+          "value": "us-east-1"
+        }
+      ],
+      "mountPoints": [
+        {
+          "sourceVolume": "shared-volume",
+          "containerPath": "/etc/secrets"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "ssm-file-downloader"
+        }
+      }
+    },
+    {
+      "name": "app",
+      "image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/test-app:latest",
+      "essential": true,
+      "environment": [
+        {
+          "name": "NODE_ENV",
+          "value": "production"
+        }
+      ],
+      "command": [],
+      "entryPoint": [],
+      "secrets": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "/default"
+        }
+      },
+      "portMappings": [
+        {
+          "name": "default",
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "mountPoints": [
+        {
+          "sourceVolume": "shared-volume",
+          "containerPath": "/etc/secrets"
+        }
+      ],
+      "dependsOn": [
+        {
+          "containerName": "init-container-for-secret-files",
+          "condition": "SUCCESS"
+        }
+      ]
+    },
+    {
+      "name": "metrics-secret-init",
+      "image": "public.ecr.aws/aws-cli/aws-cli:latest",
+      "essential": false,
+      "entryPoint": [
+        "/bin/sh"
+      ],
+      "command": [
+        "-c",
+        "for secret in ${SECRET_FILES//,/ }; do   echo \"Fetching $secret...\";   echo \"Debug: AWS_REGION=$AWS_REGION, SECRET_PATH=/etc/metrics-secrets\";   SECRET_VALUE=$(aws secretsmanager get-secret-value --secret-id $secret --region $AWS_REGION --query SecretString --output text 2>/dev/null);   STRING_RESULT=$?;   if [ $STRING_RESULT -eq 0 ] && [ -n \"$SECRET_VALUE\" ] && [ \"$SECRET_VALUE\" != \"null\" ] && [ \"$SECRET_VALUE\" != \"none\" ] && [ \"$SECRET_VALUE\" != \"None\" ]; then     echo \"Found text secret, saving to /etc/metrics-secrets/$secret\";     echo \"$SECRET_VALUE\" > /etc/metrics-secrets/$secret;   else     echo \"Text retrieval failed or returned null, trying binary retrieval...\";     aws secretsmanager get-secret-value --secret-id $secret --region $AWS_REGION --query SecretBinary --output text | base64 -d > /etc/metrics-secrets/$secret 2>/dev/null;     BINARY_RESULT=$?;     if [ $BINARY_RESULT -eq 0 ] && [ -s /etc/metrics-secrets/$secret ]; then       echo \"Found binary secret, saved to /etc/metrics-secrets/$secret\";     else       echo \"\u274c Failed to retrieve $secret as either text or binary\" >&2;       echo \"Text result: $STRING_RESULT, Binary result: $BINARY_RESULT\" >&2;       exit 1;     fi;   fi;   echo \"\u2705 Successfully saved $secret to /etc/metrics-secrets/$secret (size: $(stat -c%s /etc/metrics-secrets/$secret 2>/dev/null || wc -c < /etc/metrics-secrets/$secret))\"; done"
+      ],
+      "environment": [
+        {
+          "name": "SECRET_FILES",
+          "value": "metrics-client-cert"
+        },
+        {
+          "name": "AWS_REGION",
+          "value": "us-east-1"
+        }
+      ],
+      "mountPoints": [
+        {
+          "sourceVolume": "metrics-secrets",
+          "containerPath": "/etc/metrics-secrets"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "metrics-secret-init"
+        }
+      },
+      "readonlyRootFilesystem": true
+    },
+    {
+      "name": "metrics",
+      "image": "public.ecr.aws/my-org/metrics-agent:v1.4.2",
+      "essential": false,
+      "environment": [
+        {
+          "name": "NODE_ENV",
+          "value": "production"
+        },
+        {
+          "name": "LOG_LEVEL",
+          "value": "info"
+        },
+        {
+          "name": "DATABASE_URL",
+          "value": "postgresql://default-host:5432/db"
+        },
+        {
+          "name": "AGENT_MODE",
+          "value": "push"
+        },
+        {
+          "name": "SCRAPE_INTERVAL",
+          "value": "15"
+        }
+      ],
+      "command": [
+        "exec /usr/bin/metrics-agent --listen :9090"
+      ],
+      "entryPoint": [
+        "/bin/sh",
+        "-c"
+      ],
+      "secrets": [
+        {
+          "name": "REMOTE_WRITE_USER",
+          "valueFrom": "arn:aws:secretsmanager:us-east-1:123456789012:secret:metrics-abc123:REMOTE_WRITE_USER::"
+        },
+        {
+          "name": "REMOTE_WRITE_PASSWORD",
+          "valueFrom": "arn:aws:secretsmanager:us-east-1:123456789012:secret:metrics-abc123:REMOTE_WRITE_PASSWORD::"
+        }
+      ],
+      "stopTimeout": 5,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "metrics-agent"
+        }
+      },
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "wget -q -O- http://127.0.0.1:9090/-/healthy || exit 1"
+        ],
+        "interval": 15,
+        "timeout": 3,
+        "retries": 2,
+        "startPeriod": 20
+      },
+      "portMappings": [
+        {
+          "name": "metrics-9090-tcp",
+          "containerPort": 9090,
+          "hostPort": 9090,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        },
+        {
+          "name": "agent-admin",
+          "containerPort": 9091,
+          "hostPort": 9091,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "linuxParameters": {
+        "initProcessEnabled": true,
+        "capabilities": {
+          "drop": [
+            "ALL"
+          ]
+        }
+      },
+      "cpu": 128,
+      "memory": 256,
+      "memoryReservation": 128,
+      "readonlyRootFilesystem": true,
+      "mountPoints": [
+        {
+          "sourceVolume": "metrics-secrets",
+          "containerPath": "/etc/metrics-secrets"
+        },
+        {
+          "sourceVolume": "metrics-writable-tmp",
+          "containerPath": "/tmp"
+        },
+        {
+          "sourceVolume": "metrics-writable-var-run",
+          "containerPath": "/var/run"
+        }
+      ],
+      "dependsOn": [
+        {
+          "containerName": "metrics-secret-init",
+          "condition": "SUCCESS"
+        }
+      ]
+    }
+  ],
+  "cpu": "1024",
+  "memory": "2048",
+  "family": "test-cluster_test-service",
+  "taskRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "executionRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "volumes": [
+    {
+      "name": "shared-volume",
+      "host": {}
+    },
+    {
+      "name": "metrics-secrets",
+      "host": {}
+    },
+    {
+      "name": "metrics-writable-tmp",
+      "host": {}
+    },
+    {
+      "name": "metrics-writable-var-run",
+      "host": {}
+    }
+  ]
+}

--- a/tests/expected_outputs/sidecar-minimal.json
+++ b/tests/expected_outputs/sidecar-minimal.json
@@ -1,0 +1,65 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/test-app:latest",
+      "essential": true,
+      "environment": [
+        {
+          "name": "NODE_ENV",
+          "value": "production"
+        }
+      ],
+      "command": [],
+      "entryPoint": [],
+      "secrets": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "/default"
+        }
+      },
+      "portMappings": [
+        {
+          "name": "default",
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ]
+    },
+    {
+      "name": "metrics-proxy",
+      "image": "public.ecr.aws/nginx/nginx:1.27",
+      "essential": true,
+      "environment": [],
+      "command": [],
+      "entryPoint": [],
+      "secrets": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "metrics-proxy"
+        }
+      }
+    }
+  ],
+  "cpu": "256",
+  "memory": "512",
+  "family": "test-cluster_test-service",
+  "taskRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "executionRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  }
+}

--- a/tests/expected_outputs/sidecar-readonly-bridge.json
+++ b/tests/expected_outputs/sidecar-readonly-bridge.json
@@ -1,0 +1,97 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/test-app:latest",
+      "essential": true,
+      "environment": [
+        {
+          "name": "NODE_ENV",
+          "value": "production"
+        },
+        {
+          "name": "SECRET_PATH",
+          "value": "/etc/secrets"
+        }
+      ],
+      "command": [
+        "npm",
+        "start"
+      ],
+      "entryPoint": [],
+      "secrets": [
+        {
+          "name": "CLIENT_ID",
+          "valueFrom": "arn:aws:secretsmanager::secret:app-production-IhUQht:CLIENT_ID::"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "/default"
+        }
+      },
+      "portMappings": [
+        {
+          "name": "default",
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "readonlyRootFilesystem": true,
+      "mountPoints": [
+        {
+          "sourceVolume": "writable-tmp",
+          "containerPath": "/tmp"
+        }
+      ]
+    },
+    {
+      "name": "ssm-bridge",
+      "image": "public.ecr.aws/amazonlinux/amazonlinux@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "essential": true,
+      "environment": [],
+      "command": [
+        "sleep",
+        "infinity"
+      ],
+      "entryPoint": [],
+      "secrets": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "ssm-bridge"
+        }
+      },
+      "linuxParameters": {
+        "initProcessEnabled": true
+      },
+      "readonlyRootFilesystem": false
+    }
+  ],
+  "cpu": "256",
+  "memory": "512",
+  "family": "test-cluster_test-service",
+  "taskRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "executionRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "runtimePlatform": {
+    "cpuArchitecture": "ARM64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "volumes": [
+    {
+      "name": "writable-tmp",
+      "host": {}
+    }
+  ]
+}

--- a/tests/expected_outputs/sidecar-service-overrides.json
+++ b/tests/expected_outputs/sidecar-service-overrides.json
@@ -1,0 +1,92 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/test-app:latest",
+      "essential": true,
+      "environment": [
+        {
+          "name": "LOG_LEVEL",
+          "value": "info"
+        }
+      ],
+      "command": [],
+      "entryPoint": [],
+      "secrets": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "/default"
+        }
+      },
+      "portMappings": [
+        {
+          "name": "default",
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ]
+    },
+    {
+      "name": "cache",
+      "image": "public.ecr.aws/docker/library/redis:7-alpine",
+      "essential": true,
+      "environment": [
+        {
+          "name": "REDIS_MAXMEMORY",
+          "value": "32mb"
+        },
+        {
+          "name": "REDIS_APPENDONLY",
+          "value": "no"
+        }
+      ],
+      "command": [],
+      "entryPoint": [],
+      "secrets": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "cache"
+        }
+      },
+      "memoryReservation": 128
+    },
+    {
+      "name": "audit-tailer",
+      "image": "public.ecr.aws/my-org/audit-tailer:v1",
+      "essential": false,
+      "environment": [],
+      "command": [],
+      "entryPoint": [],
+      "secrets": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "audit-tailer"
+        }
+      }
+    }
+  ],
+  "cpu": "512",
+  "memory": "1024",
+  "family": "test-cluster_test-service",
+  "taskRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "executionRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  }
+}

--- a/tests/expected_outputs/sidecar-two-writable-tmp.json
+++ b/tests/expected_outputs/sidecar-two-writable-tmp.json
@@ -1,0 +1,117 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/test-app:latest",
+      "essential": true,
+      "environment": [],
+      "command": [],
+      "entryPoint": [],
+      "secrets": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "/default"
+        }
+      },
+      "portMappings": [
+        {
+          "name": "default",
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "readonlyRootFilesystem": true,
+      "mountPoints": [
+        {
+          "sourceVolume": "writable-tmp",
+          "containerPath": "/tmp"
+        }
+      ]
+    },
+    {
+      "name": "cache",
+      "image": "public.ecr.aws/docker/library/redis:7-alpine",
+      "essential": true,
+      "environment": [],
+      "command": [],
+      "entryPoint": [],
+      "secrets": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "cache"
+        }
+      },
+      "readonlyRootFilesystem": true,
+      "mountPoints": [
+        {
+          "sourceVolume": "cache-writable-tmp",
+          "containerPath": "/tmp"
+        }
+      ]
+    },
+    {
+      "name": "shipper",
+      "image": "public.ecr.aws/my-org/log-shipper:v2",
+      "essential": true,
+      "environment": [],
+      "command": [],
+      "entryPoint": [],
+      "secrets": [
+        {
+          "name": "SHIPPER_TOKEN",
+          "valueFrom": "arn:aws:secretsmanager::secret:log-shipper-token-XyZ123:SHIPPER_TOKEN::"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/test-cluster/test-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "shipper"
+        }
+      },
+      "readonlyRootFilesystem": true,
+      "mountPoints": [
+        {
+          "sourceVolume": "shipper-writable-tmp",
+          "containerPath": "/tmp"
+        }
+      ]
+    }
+  ],
+  "cpu": "512",
+  "memory": "1024",
+  "family": "test-cluster_test-service",
+  "taskRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "executionRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "volumes": [
+    {
+      "name": "writable-tmp",
+      "host": {}
+    },
+    {
+      "name": "cache-writable-tmp",
+      "host": {}
+    },
+    {
+      "name": "shipper-writable-tmp",
+      "host": {}
+    }
+  ]
+}

--- a/tests/test_sidecars.py
+++ b/tests/test_sidecars.py
@@ -1,0 +1,881 @@
+#!/usr/bin/env python3
+"""
+Unit tests for generic sidecar support in generate_task_def.py.
+
+These cover what the golden-file runner in test.py cannot: configurations that
+must be *rejected* (test.py has no mechanism for an expected failure), and the
+isolation guarantees, which are easier to assert directly than to eyeball in a
+JSON fixture.
+
+boto3 is never imported: every secret here uses an explicit ARN, so no test
+needs AWS credentials.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_module():
+    """Import generate_task_def.py by path (same approach as test_roles.py)."""
+    script = Path(__file__).parent.parent / "scripts" / "generate_task_def.py"
+    spec = importlib.util.spec_from_file_location("generate_task_def", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gtd = load_module()
+
+CLUSTER = "test-cluster"
+REGION = "us-east-1"
+SERVICE = "test-service"
+ROLE = "arn:aws:iam::123456789012:role/ecsTaskExecutionRole"
+
+
+def base_config(**overrides):
+    """A minimal valid config; keyword arguments are merged on top."""
+    config = {'cpu': 256, 'memory': 512, 'role_arn': ROLE}
+    config.update(overrides)
+    return config
+
+
+def generate(config):
+    """Render a task definition from a config dict."""
+    return gtd.generate_task_definition(
+        config_dict=config,
+        cluster_name=CLUSTER,
+        aws_region=REGION,
+        registry="123456789012.dkr.ecr.us-east-1.amazonaws.com",
+        container_registry="123456789012.dkr.ecr.us-east-1.amazonaws.com",
+        image_name="test-app",
+        tag="latest",
+        service_name=SERVICE,
+    )
+
+
+def containers(task_definition):
+    """Container definitions keyed by name."""
+    return {c['name']: c for c in task_definition['containerDefinitions']}
+
+
+def volume_names(task_definition):
+    return [v['name'] for v in task_definition.get('volumes', [])]
+
+
+def expect_validation_error(config, *fragments):
+    """Assert rendering fails with a ValidationError naming every fragment."""
+    try:
+        generate(config)
+    except gtd.ValidationError as e:
+        message = str(e)
+        missing = [f for f in fragments if f not in message]
+        if missing:
+            return False, f"message missing {missing}: {message}"
+        return True, message.split('\n')[0][:90]
+    except Exception as e:  # noqa: BLE001 - wrong exception type is a failure
+        return False, f"raised {type(e).__name__} instead of ValidationError: {e}"
+    return False, "no error raised"
+
+
+# ---------------------------------------------------------------------------
+# The motivating case: read-only app + writable ECS Exec bridge
+# ---------------------------------------------------------------------------
+
+BRIDGE_CONFIG = base_config(
+    port=8080,
+    readonly_root_filesystem=True,
+    writable_dirs=['/tmp'],
+    envs=[{'NODE_ENV': 'production'}],
+    secrets=[{'CLIENT_ID': 'arn:aws:secretsmanager::secret:app-prod-IhUQht'}],
+    secret_files=['app-certificate'],
+    sidecars=[{
+        'name': 'ssm-bridge',
+        'image': 'public.ecr.aws/amazonlinux/amazonlinux:2023',
+        'command': ['sleep', 'infinity'],
+        'readonly_root_filesystem': False,
+        'linux_parameters': {'init_process_enabled': True},
+    }],
+)
+
+
+def test_app_stays_readonly():
+    app = containers(generate(BRIDGE_CONFIG))['app']
+    if app.get('readonlyRootFilesystem') is not True:
+        return False, f"app readonlyRootFilesystem={app.get('readonlyRootFilesystem')}"
+    return True, "app readonlyRootFilesystem=True"
+
+
+def test_bridge_overrides_readonly():
+    bridge = containers(generate(BRIDGE_CONFIG))['ssm-bridge']
+    if bridge.get('readonlyRootFilesystem') is not False:
+        return False, f"ssm-bridge readonlyRootFilesystem={bridge.get('readonlyRootFilesystem')}"
+    return True, "explicit false beats the top-level true"
+
+
+def test_bridge_receives_nothing_from_app():
+    """The bridge must not inherit the application's env, secrets or mounts."""
+    bridge = containers(generate(BRIDGE_CONFIG))['ssm-bridge']
+    leaks = []
+    if bridge.get('environment'):
+        leaks.append(f"environment={bridge['environment']}")
+    if bridge.get('secrets'):
+        leaks.append(f"secrets={bridge['secrets']}")
+    if bridge.get('mountPoints'):
+        leaks.append(f"mountPoints={bridge['mountPoints']}")
+    if bridge.get('portMappings'):
+        leaks.append(f"portMappings={bridge['portMappings']}")
+    if bridge.get('dependsOn'):
+        leaks.append(f"dependsOn={bridge['dependsOn']}")
+    if leaks:
+        return False, "leaked from app: " + "; ".join(leaks)
+    return True, "no application env, secrets, mounts, ports or dependencies"
+
+
+def test_bridge_keeps_empty_skeleton_keys():
+    bridge = containers(generate(BRIDGE_CONFIG))['ssm-bridge']
+    for key in ('environment', 'secrets', 'entryPoint'):
+        if key not in bridge:
+            return False, f"missing skeleton key '{key}'"
+    return True, "environment/secrets/entryPoint present but empty"
+
+
+def test_bridge_gets_own_linux_parameters():
+    bridge = containers(generate(BRIDGE_CONFIG))['ssm-bridge']
+    if bridge.get('linuxParameters') != {'initProcessEnabled': True}:
+        return False, f"linuxParameters={bridge.get('linuxParameters')}"
+    return True, "initProcessEnabled honored"
+
+
+def test_app_init_container_untouched_by_sidecars():
+    """Adding a sidecar must not change the application's own containers."""
+    with_sidecar = containers(generate(BRIDGE_CONFIG))
+    without = dict(BRIDGE_CONFIG)
+    without.pop('sidecars')
+    baseline = containers(generate(without))
+    for name, container in baseline.items():
+        if with_sidecar.get(name) != container:
+            return False, f"container '{name}' changed when a sidecar was added"
+    return True, f"{len(baseline)} application container(s) byte-identical"
+
+
+# ---------------------------------------------------------------------------
+# Isolation and per-container defaults
+# ---------------------------------------------------------------------------
+
+def test_sidecar_inherits_readonly_when_unset():
+    config = base_config(
+        readonly_root_filesystem=True,
+        sidecars=[{'name': 'tailer', 'image': 'busybox'}],
+    )
+    tailer = containers(generate(config))['tailer']
+    if tailer.get('readonlyRootFilesystem') is not True:
+        return False, f"readonlyRootFilesystem={tailer.get('readonlyRootFilesystem')}"
+    return True, "falls back to the application value"
+
+
+def test_readonly_key_omitted_when_unset_everywhere():
+    config = base_config(sidecars=[{'name': 'tailer', 'image': 'busybox'}])
+    rendered = containers(generate(config))
+    present = [n for n, c in rendered.items() if 'readonlyRootFilesystem' in c]
+    if present:
+        return False, f"readonlyRootFilesystem emitted for {present}"
+    return True, "key omitted entirely, as before"
+
+
+def test_sidecar_defaults_to_essential():
+    config = base_config(sidecars=[{'name': 'tailer', 'image': 'busybox'}])
+    if containers(generate(config))['tailer']['essential'] is not True:
+        return False, "essential did not default to True"
+    return True, "essential defaults to True (the ECS default)"
+
+
+def test_sidecar_gets_own_env_secrets_files_and_mounts():
+    config = base_config(
+        envs=[{'APP_ONLY': 'yes'}],
+        sidecars=[{
+            'name': 'metrics',
+            'image': 'metrics:1',
+            'envs': [{'AGENT_MODE': 'push'}],
+            'secrets_envs': [{
+                'id': 'arn:aws:secretsmanager:us-east-1:123456789012:secret:m-abc',
+                'values': ['TOKEN'],
+            }],
+            'secret_files': ['client-cert'],
+            'writable_dirs': ['/tmp'],
+        }],
+    )
+    rendered = containers(generate(config))
+    metrics = rendered['metrics']
+
+    if [e['name'] for e in metrics['environment']] != ['AGENT_MODE']:
+        return False, f"environment={metrics['environment']}"
+    if [s['name'] for s in metrics['secrets']] != ['TOKEN']:
+        return False, f"secrets={metrics['secrets']}"
+    if 'metrics-secret-init' not in rendered:
+        return False, "no init container generated for the sidecar's secret_files"
+    mounts = {m['sourceVolume'] for m in metrics['mountPoints']}
+    if mounts != {'metrics-secrets', 'metrics-writable-tmp'}:
+        return False, f"mountPoints={mounts}"
+    if metrics['dependsOn'] != [{'containerName': 'metrics-secret-init',
+                                 'condition': 'SUCCESS'}]:
+        return False, f"dependsOn={metrics['dependsOn']}"
+
+    app = rendered['app']
+    if [e['name'] for e in app['environment']] != ['APP_ONLY']:
+        return False, f"app environment polluted: {app['environment']}"
+    if app.get('mountPoints'):
+        return False, f"app gained the sidecar's mounts: {app['mountPoints']}"
+    return True, "sidecar env/secrets/files/mounts are its own"
+
+
+def test_secrets_are_never_resolved_to_plaintext():
+    config = base_config(sidecars=[{
+        'name': 'metrics',
+        'image': 'metrics:1',
+        'secrets': [{'TOKEN': 'arn:aws:secretsmanager::secret:tok-AbCdEf'}],
+    }])
+    secrets = containers(generate(config))['metrics']['secrets']
+    if secrets != [{'name': 'TOKEN',
+                    'valueFrom': 'arn:aws:secretsmanager::secret:tok-AbCdEf:TOKEN::'}]:
+        return False, f"secrets={secrets}"
+    return True, "stays a valueFrom reference"
+
+
+def test_app_writable_dirs_not_copied_into_sidecar():
+    config = base_config(
+        writable_dirs=['/tmp', '/var/run'],
+        sidecars=[{'name': 'tailer', 'image': 'busybox'}],
+    )
+    rendered = generate(config)
+    tailer = containers(rendered)['tailer']
+    if tailer.get('mountPoints'):
+        return False, f"sidecar mounted application volumes: {tailer['mountPoints']}"
+    if volume_names(rendered) != ['writable-tmp', 'writable-var-run']:
+        return False, f"volumes={volume_names(rendered)}"
+    return True, "application writable_dirs stay with the application"
+
+
+def test_two_sidecars_sharing_tmp_get_distinct_volumes():
+    config = base_config(
+        writable_dirs=['/tmp'],
+        sidecars=[
+            {'name': 'cache', 'image': 'redis', 'writable_dirs': ['/tmp']},
+            {'name': 'shipper', 'image': 'shipper', 'writable_dirs': ['/tmp']},
+        ],
+    )
+    rendered = generate(config)
+    expected = ['writable-tmp', 'cache-writable-tmp', 'shipper-writable-tmp']
+    if volume_names(rendered) != expected:
+        return False, f"volumes={volume_names(rendered)}"
+
+    rendered_containers = containers(rendered)
+    for name, volume in (('cache', 'cache-writable-tmp'),
+                         ('shipper', 'shipper-writable-tmp')):
+        mounts = rendered_containers[name]['mountPoints']
+        if mounts != [{'sourceVolume': volume, 'containerPath': '/tmp'}]:
+            return False, f"{name} mountPoints={mounts}"
+    return True, "three distinct /tmp volumes"
+
+
+def test_sidecar_logs_to_service_log_group_with_name_prefix():
+    config = base_config(sidecars=[
+        {'name': 'tailer', 'image': 'busybox'},
+        {'name': 'shipper', 'image': 'busybox', 'log_stream_prefix': 'custom'},
+    ])
+    rendered = containers(generate(config))
+    options = rendered['tailer']['logConfiguration']['options']
+    if options['awslogs-group'] != f"/ecs/{CLUSTER}/{SERVICE}":
+        return False, f"awslogs-group={options['awslogs-group']}"
+    if options['awslogs-stream-prefix'] != 'tailer':
+        return False, f"awslogs-stream-prefix={options['awslogs-stream-prefix']}"
+    custom = rendered['shipper']['logConfiguration']['options']
+    if custom['awslogs-stream-prefix'] != 'custom':
+        return False, f"custom prefix ignored: {custom['awslogs-stream-prefix']}"
+    return True, "service log group, sidecar name as default prefix"
+
+
+def test_sidecar_stays_on_awslogs_under_fluent_bit():
+    config = base_config(
+        fluent_bit_collector={'image_name': 'fluent-bit:latest'},
+        sidecars=[{'name': 'tailer', 'image': 'busybox'}],
+    )
+    rendered = containers(generate(config))
+    if rendered['app']['logConfiguration']['logDriver'] != 'awsfirelens':
+        return False, "application did not switch to awsfirelens"
+    driver = rendered['tailer']['logConfiguration']['logDriver']
+    if driver != 'awslogs':
+        return False, f"sidecar logDriver={driver}"
+    return True, "sidecar keeps awslogs, like fluent-bit and otel do"
+
+
+def test_sidecar_reservations_are_integers():
+    config = base_config(sidecars=[{
+        'name': 'metrics', 'image': 'metrics:1',
+        'cpu': 128, 'memory': 256, 'memory_reservation': 128,
+    }])
+    metrics = containers(generate(config))['metrics']
+    for key, expected in (('cpu', 128), ('memory', 256), ('memoryReservation', 128)):
+        if metrics.get(key) != expected or not isinstance(metrics.get(key), int):
+            return False, f"{key}={metrics.get(key)!r}"
+    return True, "cpu/memory/memoryReservation emitted as ints"
+
+
+def test_sidecar_port_mapping_name_is_unique():
+    config = base_config(
+        port=8080,
+        sidecars=[{'name': 'metrics', 'image': 'metrics:1', 'port': 9090}],
+    )
+    rendered = containers(generate(config))
+    app_names = [p['name'] for p in rendered['app']['portMappings']]
+    sidecar_names = [p['name'] for p in rendered['metrics']['portMappings']]
+    if app_names != ['default']:
+        return False, f"application port names changed: {app_names}"
+    if sidecar_names != ['metrics-9090-tcp']:
+        return False, f"sidecar port names={sidecar_names}"
+    return True, "default vs metrics-9090-tcp"
+
+
+def test_sidecar_ordering():
+    config = base_config(
+        secret_files=['app-cert'],
+        fluent_bit_collector={'image_name': 'fluent-bit:latest'},
+        otel_collector={'image_name': ''},
+        sidecars=[
+            {'name': 'metrics', 'image': 'm:1', 'secret_files': ['cert']},
+            {'name': 'tailer', 'image': 't:1'},
+        ],
+    )
+    names = [c['name'] for c in generate(config)['containerDefinitions']]
+    expected = ['init-container-for-secret-files', 'app', 'fluent-bit',
+                'otel-collector', 'metrics-secret-init', 'metrics', 'tailer']
+    if names != expected:
+        return False, f"order={names}"
+    return True, "application containers first, then sidecars in order"
+
+
+# ---------------------------------------------------------------------------
+# services_overrides
+# ---------------------------------------------------------------------------
+
+OVERRIDE_CONFIG = {
+    'cpu': 256, 'memory': 512, 'role_arn': ROLE,
+    'sidecars': [
+        {'name': 'ssm-bridge', 'image': 'amazonlinux:2023',
+         'command': ['sleep', 'infinity']},
+        {'name': 'cache', 'image': 'redis:7', 'memory_reservation': 64,
+         'envs': [{'REDIS_MAXMEMORY': '32mb'}]},
+    ],
+    'services_overrides': {
+        SERVICE: {
+            'sidecars': [
+                {'name': 'ssm-bridge', 'enabled': False},
+                {'name': 'cache', 'memory_reservation': 128,
+                 'envs': [{'REDIS_APPENDONLY': 'no'}]},
+                {'name': 'audit-tailer', 'image': 'audit:v1', 'essential': False},
+            ],
+        },
+        'other-service': {},
+    },
+}
+
+
+def merged_for(service):
+    return gtd.apply_service_overrides(OVERRIDE_CONFIG, service)
+
+
+def test_override_disables_sidecar():
+    merged = merged_for(SERVICE)
+    names = [s['name'] for s in gtd.enabled_sidecars(merged)]
+    if 'ssm-bridge' in names:
+        return False, f"ssm-bridge still enabled: {names}"
+    if len(merged['sidecars']) != 3:
+        return False, f"disabled sidecar was dropped from the merged config instead of flagged"
+    return True, "enabled: false removes it from the task definition"
+
+
+def test_override_merges_by_name_not_append():
+    cache = next(s for s in merged_for(SERVICE)['sidecars'] if s['name'] == 'cache')
+    if cache['memory_reservation'] != 128:
+        return False, f"scalar not replaced: {cache['memory_reservation']}"
+    if cache['image'] != 'redis:7':
+        return False, f"base image lost: {cache['image']}"
+    keys = [k for e in cache['envs'] for k in e]
+    if keys != ['REDIS_MAXMEMORY', 'REDIS_APPENDONLY']:
+        return False, f"envs did not extend: {keys}"
+    return True, "scalars replace, arrays extend, base fields preserved"
+
+
+def test_override_appends_new_sidecar():
+    names = [s['name'] for s in merged_for(SERVICE)['sidecars']]
+    if names != ['ssm-bridge', 'cache', 'audit-tailer']:
+        return False, f"order/content={names}"
+    return True, "unmatched names appended, base order preserved"
+
+
+def test_other_service_keeps_base_sidecars():
+    names = [s['name'] for s in gtd.enabled_sidecars(merged_for('other-service'))]
+    if names != ['ssm-bridge', 'cache']:
+        return False, f"base config affected: {names}"
+    return True, "a service with no sidecar override is unaffected"
+
+
+def test_override_null_removes_all_sidecars():
+    config = dict(OVERRIDE_CONFIG)
+    config['services_overrides'] = {SERVICE: {'sidecars': None}}
+    if 'sidecars' in merged_for_config(config):
+        return False, "sidecars survived an explicit null"
+    return True, "sidecars: null is the per-service escape hatch"
+
+
+def merged_for_config(config):
+    return gtd.apply_service_overrides(config, SERVICE)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def test_rejects_non_list_sidecars():
+    return expect_validation_error(base_config(sidecars='oops'),
+                                   'sidecars must be a list', 'str')
+
+
+def test_rejects_non_mapping_entry():
+    return expect_validation_error(base_config(sidecars=['oops']),
+                                   'sidecars[0] must be a mapping')
+
+
+def test_rejects_missing_name():
+    return expect_validation_error(base_config(sidecars=[{'image': 'busybox'}]),
+                                   "'name' is required")
+
+
+def test_rejects_missing_image():
+    return expect_validation_error(base_config(sidecars=[{'name': 'tailer'}]),
+                                   "'image' is required")
+
+
+def test_rejects_unknown_key():
+    config = base_config(sidecars=[{
+        'name': 'tailer', 'image': 'busybox', 'readonly_root_filesytem': False,
+    }])
+    return expect_validation_error(config, 'unsupported key',
+                                   'readonly_root_filesytem')
+
+
+def test_rejects_duplicate_names():
+    config = base_config(sidecars=[
+        {'name': 'tailer', 'image': 'a'},
+        {'name': 'tailer', 'image': 'b'},
+    ])
+    return expect_validation_error(config, "Duplicate container name 'tailer'")
+
+
+def test_rejects_reserved_names():
+    for reserved in ('app', 'fluent-bit', 'otel-collector',
+                     'init-container-for-secret-files', 'default'):
+        config = base_config(sidecars=[{'name': reserved, 'image': 'busybox'}])
+        passed, detail = expect_validation_error(
+            config, f"Duplicate container name '{reserved}'", 'reserved')
+        if not passed:
+            return False, f"{reserved}: {detail}"
+    return True, "app, fluent-bit, otel-collector, init container and default"
+
+
+def test_rejects_collision_with_generated_init_name():
+    config = base_config(sidecars=[
+        {'name': 'metrics', 'image': 'a', 'secret_files': ['cert']},
+        {'name': 'metrics-secret-init', 'image': 'b'},
+    ])
+    return expect_validation_error(
+        config, "Duplicate container name 'metrics-secret-init'")
+
+
+def test_rejects_volume_collision_with_application():
+    """A sidecar named 'writable' with secret files generates writable-secrets,
+    which is also what the application's writable_dirs: [/secrets] produces."""
+    config = base_config(
+        writable_dirs=['/secrets'],
+        sidecars=[{'name': 'writable', 'image': 'busybox',
+                   'secret_files': ['cert']}],
+    )
+    return expect_validation_error(config, "'writable-secrets'",
+                                   'application-level volume')
+
+
+def test_rejects_invalid_generated_volume_name():
+    config = base_config(sidecars=[{
+        'name': 'cache', 'image': 'busybox', 'writable_dirs': ['/var/lib/.cache'],
+    }])
+    return expect_validation_error(config, 'not a valid ECS volume name',
+                                   'cache-writable-var-lib-.cache')
+
+
+def test_rejects_invalid_sidecar_name():
+    config = base_config(sidecars=[{'name': '-bad name', 'image': 'busybox'}])
+    return expect_validation_error(config, 'invalid container name')
+
+
+def test_rejects_duplicate_port_mapping_name():
+    config = base_config(
+        port=8080,
+        additional_ports=[{'admin': 8081}],
+        sidecars=[{'name': 'metrics', 'image': 'm:1',
+                   'additional_ports': [{'admin': 9091}]}],
+    )
+    return expect_validation_error(config, "Duplicate port mapping name 'admin'")
+
+
+def test_rejects_memory_reservation_above_memory():
+    config = base_config(sidecars=[{
+        'name': 'metrics', 'image': 'm:1', 'memory': 128, 'memory_reservation': 256,
+    }])
+    return expect_validation_error(config, 'memory_reservation', 'must not exceed')
+
+
+def test_rejects_wrong_types():
+    cases = [
+        ({'envs': 'NODE_ENV=x'}, "'envs' must be a list"),
+        ({'health_check': ['curl']}, "'health_check' must be a mapping"),
+        ({'image': 42}, "'image' is required and must be a string"),
+        ({'essential': 'yes'}, "'essential' must be true or false"),
+        ({'port': 0}, "'port' must be a positive integer"),
+        ({'port': True}, "'port' must be a positive integer"),
+        ({'cpu': '128'}, "'cpu' must be a positive integer"),
+    ]
+    for extra, fragment in cases:
+        sidecar = {'name': 'tailer', 'image': 'busybox'}
+        sidecar.update(extra)
+        passed, detail = expect_validation_error(base_config(sidecars=[sidecar]),
+                                                 fragment)
+        if not passed:
+            return False, f"{extra}: {detail}"
+    return True, f"{len(cases)} type errors reported clearly"
+
+
+def test_only_explicit_false_disables():
+    """`enabled:` with an empty value parses as None and must not drop it."""
+    config = base_config(sidecars=[
+        {'name': 'kept-null', 'image': 'busybox', 'enabled': None},
+        {'name': 'kept-true', 'image': 'busybox', 'enabled': True},
+        {'name': 'dropped', 'image': 'busybox', 'enabled': False},
+    ])
+    names = [c['name'] for c in generate(config)['containerDefinitions']]
+    if names != ['app', 'kept-null', 'kept-true']:
+        return False, f"containers={names}"
+    return True, "only enabled: false removes a sidecar"
+
+
+def test_app_only_duplicate_port_names_still_allowed():
+    """Pre-existing app-level duplicates are not this feature's business."""
+    config = base_config(
+        additional_ports=[{'admin': 8081}, {'admin': 8082}],
+        sidecars=[{'name': 'tailer', 'image': 'busybox'}],
+    )
+    try:
+        generate(config)
+    except gtd.ValidationError as e:
+        return False, f"rejected a pre-existing config: {e}"
+    return True, "only collisions involving a sidecar are reported"
+
+
+def test_rejects_sidecars_exceeding_task_memory():
+    config = base_config(
+        memory=512,
+        sidecars=[{'name': 'a', 'image': 'i', 'memory': 256},
+                  {'name': 'b', 'image': 'i', 'memory': 256}],
+    )
+    return expect_validation_error(config, 'Sidecars reserve 512 MiB',
+                                   'a=256, b=256', 'only has 512')
+
+
+def test_rejects_sidecars_exceeding_task_cpu():
+    config = base_config(cpu=256, sidecars=[{'name': 'a', 'image': 'i', 'cpu': 256}])
+    return expect_validation_error(config, 'CPU units', 'only has 256')
+
+
+def test_resource_budget_not_enforced_on_ec2():
+    config = base_config(
+        launch_type='EC2', cpu=256, memory=512,
+        sidecars=[{'name': 'a', 'image': 'i', 'memory': 4096}],
+    )
+    try:
+        generate(config)
+    except gtd.ValidationError as e:
+        return False, f"EC2 task rejected: {e}"
+    return True, "EC2 task-level values are advisory"
+
+
+def test_disabled_sidecar_frees_the_resource_budget():
+    config = base_config(
+        memory=512,
+        sidecars=[{'name': 'a', 'image': 'i', 'memory': 4096, 'enabled': False}],
+    )
+    try:
+        generate(config)
+    except gtd.ValidationError as e:
+        return False, f"disabled sidecar still counted: {e}"
+    return True, "a disabled sidecar reserves nothing"
+
+
+# ---------------------------------------------------------------------------
+# Explicit YAML nulls. `command:` with nothing after it parses as None, and
+# validation treats that as "unset" - so every consumer has to agree.
+# ---------------------------------------------------------------------------
+
+def test_blank_list_keys_do_not_crash():
+    for key in ('command', 'entrypoint', 'envs', 'envs_from_files', 'secrets',
+                'secrets_envs', 'secret_files', 'writable_dirs', 'additional_ports'):
+        sidecar = {'name': 'tailer', 'image': 'busybox', key: None}
+        try:
+            rendered = containers(generate(base_config(sidecars=[sidecar])))['tailer']
+        except gtd.ValidationError as e:
+            return False, f"{key}: rejected a blank value: {e}"
+        except Exception as e:  # noqa: BLE001
+            return False, f"{key}: crashed with {type(e).__name__}: {e}"
+        for emitted, value in rendered.items():
+            if value is None:
+                return False, f"{key}: emitted null for '{emitted}'"
+    return True, "9 blank list keys behave as absent"
+
+
+def test_blank_command_does_not_emit_null():
+    """`"command": null` is rejected by RegisterTaskDefinition, not by us."""
+    config = base_config(sidecars=[{'name': 't', 'image': 'busybox', 'command': None}])
+    tailer = containers(generate(config))['t']
+    if tailer['command'] != [] or tailer['entryPoint'] != []:
+        return False, f"command={tailer['command']!r} entryPoint={tailer['entryPoint']!r}"
+    return True, "blank command renders as []"
+
+
+def test_blank_essential_stays_essential():
+    """bool(None) is False - a blank `essential:` must not silently disarm it."""
+    config = base_config(sidecars=[{'name': 't', 'image': 'busybox', 'essential': None}])
+    if containers(generate(config))['t']['essential'] is not True:
+        return False, "a blank essential: made the sidecar non-essential"
+    return True, "blank essential: still means essential"
+
+
+def test_disabled_sidecar_env_file_is_not_resolved(tmp_yaml=None):
+    """Turning a sidecar off must let its dotenv file be deleted with it."""
+    import tempfile
+    import textwrap
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / 'task.yaml'
+        path.write_text(textwrap.dedent(f"""
+            cpu: 256
+            memory: 512
+            role_arn: {ROLE}
+            sidecars:
+              - name: legacy-agent
+                image: acme/agent:1.0
+                enabled: false
+                envs_from_files:
+                  - ./deleted-when-the-sidecar-was.env
+        """))
+        try:
+            config = gtd.load_and_validate_config(str(path), SERVICE)
+        except gtd.ValidationError as e:
+            return False, f"disabled sidecar still resolved its env file: {e}"
+    if gtd.enabled_sidecars(config):
+        return False, "the disabled sidecar was rendered"
+    return True, "a switched-off sidecar resolves nothing"
+
+
+# ---------------------------------------------------------------------------
+# Port and log-stream namespaces, which are task-wide rather than per container
+# ---------------------------------------------------------------------------
+
+def test_rejects_duplicate_container_port_under_awsvpc():
+    config = base_config(
+        port=8080,
+        sidecars=[{'name': 'proxy', 'image': 'nginx', 'port': 8080}],
+    )
+    return expect_validation_error(config, 'Duplicate container port 8080',
+                                   'same port')
+
+
+def test_allows_duplicate_container_port_under_bridge():
+    """Bridge mode assigns host ports dynamically, so this is legal."""
+    config = base_config(
+        launch_type='EC2', network_mode='bridge', port=8080,
+        sidecars=[{'name': 'proxy', 'image': 'nginx', 'port': 8080}],
+    )
+    try:
+        generate(config)
+    except gtd.ValidationError as e:
+        return False, f"rejected a legal bridge-mode config: {e}"
+    return True, "bridge mode allows it"
+
+
+def test_rejects_port_colliding_with_otel_collector():
+    config = base_config(
+        otel_collector={'image_name': ''},
+        sidecars=[{'name': 'tap', 'image': 't:1', 'port': 4317}],
+    )
+    return expect_validation_error(config, 'Duplicate container port 4317',
+                                   'otel-collector')
+
+
+def test_rejects_invalid_generated_port_name():
+    """ECS port names are lowercase-only, unlike container names."""
+    config = base_config(sidecars=[{'name': 'My_Proxy', 'image': 'n', 'port': 8080}])
+    return expect_validation_error(config, 'Invalid port mapping name',
+                                   'My_Proxy-8080-tcp')
+
+
+def test_rejects_overlong_generated_names():
+    long_name = 'a' * 250
+    config = base_config(sidecars=[{'name': long_name, 'image': 'n',
+                                    'secret_files': ['cert']}])
+    return expect_validation_error(config, 'generated container name', 'too long')
+
+
+def test_rejects_reserved_log_stream_prefix():
+    config = base_config(sidecars=[{'name': 'proxy', 'image': 'n',
+                                    'log_stream_prefix': 'default'}])
+    return expect_validation_error(config, "log_stream_prefix 'default'", 'reserved')
+
+
+def test_rejects_malformed_list_entries():
+    cases = [
+        ({'envs': ['FOO=bar']}, 'envs entries must be single-key mappings'),
+        ({'additional_ports': [9090]}, 'additional_ports entries must be mappings'),
+        ({'additional_ports': [{'admin': 'nine'}]}, 'must be a positive integer'),
+    ]
+    for extra, fragment in cases:
+        sidecar = {'name': 'tailer', 'image': 'busybox'}
+        sidecar.update(extra)
+        passed, detail = expect_validation_error(base_config(sidecars=[sidecar]),
+                                                 fragment)
+        if not passed:
+            return False, f"{extra}: {detail}"
+    return True, "malformed entries rejected, not silently dropped"
+
+
+def test_disabled_sidecar_is_still_validated():
+    config = base_config(sidecars=[{
+        'name': 'tailer', 'image': 'busybox', 'enabled': False, 'typo': 1,
+    }])
+    return expect_validation_error(config, 'unsupported key', 'typo')
+
+
+def test_disabled_sidecar_frees_its_names():
+    """Switching one off must not make its name collide with a replacement."""
+    config = base_config(sidecars=[
+        {'name': 'cache', 'image': 'old', 'enabled': False, 'writable_dirs': ['/tmp']},
+        {'name': 'cache-writable-tmp', 'image': 'new'},
+    ])
+    names = [c['name'] for c in generate(config)['containerDefinitions']]
+    if names != ['app', 'cache-writable-tmp']:
+        return False, f"containers={names}"
+    return True, "a disabled sidecar reserves nothing"
+
+
+def test_unexpanded_envs_from_files_fails_loudly():
+    config = base_config(sidecars=[{
+        'name': 'tailer', 'image': 'busybox', 'envs_from_files': ['./x.env'],
+    }])
+    return expect_validation_error(config, 'envs_from_files was not expanded')
+
+
+def test_boto3_never_imported():
+    if 'boto3' in sys.modules:
+        return False, "boto3 was imported - a test is hitting AWS"
+    return True, "no AWS calls"
+
+
+TESTS = [
+    ("readonly bridge: app stays read-only", test_app_stays_readonly),
+    ("readonly bridge: sidecar overrides to false", test_bridge_overrides_readonly),
+    ("readonly bridge: sidecar inherits nothing from app", test_bridge_receives_nothing_from_app),
+    ("readonly bridge: empty skeleton keys emitted", test_bridge_keeps_empty_skeleton_keys),
+    ("readonly bridge: own linux_parameters", test_bridge_gets_own_linux_parameters),
+    ("adding a sidecar does not touch app containers", test_app_init_container_untouched_by_sidecars),
+    ("readonly: inherited when sidecar is silent", test_sidecar_inherits_readonly_when_unset),
+    ("readonly: key omitted when unset everywhere", test_readonly_key_omitted_when_unset_everywhere),
+    ("essential defaults to true", test_sidecar_defaults_to_essential),
+    ("sidecar gets its own env/secrets/files/mounts", test_sidecar_gets_own_env_secrets_files_and_mounts),
+    ("secrets stay valueFrom references", test_secrets_are_never_resolved_to_plaintext),
+    ("app writable_dirs not copied into sidecars", test_app_writable_dirs_not_copied_into_sidecar),
+    ("two sidecars on /tmp get distinct volumes", test_two_sidecars_sharing_tmp_get_distinct_volumes),
+    ("logging: service log group, name as prefix", test_sidecar_logs_to_service_log_group_with_name_prefix),
+    ("logging: sidecars stay on awslogs under fluent-bit", test_sidecar_stays_on_awslogs_under_fluent_bit),
+    ("cpu/memory reservations emitted as ints", test_sidecar_reservations_are_integers),
+    ("port mapping names stay unique", test_sidecar_port_mapping_name_is_unique),
+    ("container ordering", test_sidecar_ordering),
+    ("overrides: enabled false disables", test_override_disables_sidecar),
+    ("overrides: merge by name, not append", test_override_merges_by_name_not_append),
+    ("overrides: new sidecar appended", test_override_appends_new_sidecar),
+    ("overrides: other services unaffected", test_other_service_keeps_base_sidecars),
+    ("overrides: null removes all sidecars", test_override_null_removes_all_sidecars),
+    ("reject: sidecars not a list", test_rejects_non_list_sidecars),
+    ("reject: entry not a mapping", test_rejects_non_mapping_entry),
+    ("reject: missing name", test_rejects_missing_name),
+    ("reject: missing image", test_rejects_missing_image),
+    ("reject: unknown/misspelled key", test_rejects_unknown_key),
+    ("reject: duplicate names", test_rejects_duplicate_names),
+    ("reject: reserved names", test_rejects_reserved_names),
+    ("reject: collision with generated init name", test_rejects_collision_with_generated_init_name),
+    ("reject: volume collision with application", test_rejects_volume_collision_with_application),
+    ("reject: invalid generated volume name", test_rejects_invalid_generated_volume_name),
+    ("reject: invalid sidecar name", test_rejects_invalid_sidecar_name),
+    ("reject: duplicate port mapping name", test_rejects_duplicate_port_mapping_name),
+    ("reject: memory_reservation above memory", test_rejects_memory_reservation_above_memory),
+    ("reject: wrong types", test_rejects_wrong_types),
+    ("only enabled: false disables", test_only_explicit_false_disables),
+    ("app-only duplicate port names still allowed", test_app_only_duplicate_port_names_still_allowed),
+    ("reject: sidecars exceed task memory", test_rejects_sidecars_exceeding_task_memory),
+    ("reject: sidecars exceed task cpu", test_rejects_sidecars_exceeding_task_cpu),
+    ("resource budget not enforced on EC2", test_resource_budget_not_enforced_on_ec2),
+    ("disabled sidecar frees the resource budget", test_disabled_sidecar_frees_the_resource_budget),
+    ("null: blank list keys behave as absent", test_blank_list_keys_do_not_crash),
+    ("null: blank command renders as []", test_blank_command_does_not_emit_null),
+    ("null: blank essential stays essential", test_blank_essential_stays_essential),
+    ("null: disabled sidecar resolves no env file", test_disabled_sidecar_env_file_is_not_resolved),
+    ("reject: duplicate container port (awsvpc)", test_rejects_duplicate_container_port_under_awsvpc),
+    ("allow: duplicate container port (bridge)", test_allows_duplicate_container_port_under_bridge),
+    ("reject: port colliding with otel-collector", test_rejects_port_colliding_with_otel_collector),
+    ("reject: invalid generated port name", test_rejects_invalid_generated_port_name),
+    ("reject: overlong generated container name", test_rejects_overlong_generated_names),
+    ("reject: reserved log_stream_prefix", test_rejects_reserved_log_stream_prefix),
+    ("reject: malformed envs/additional_ports entries", test_rejects_malformed_list_entries),
+    ("disabled sidecar is still validated", test_disabled_sidecar_is_still_validated),
+    ("disabled sidecar reserves no names", test_disabled_sidecar_frees_its_names),
+    ("unexpanded envs_from_files fails loudly", test_unexpanded_envs_from_files_fails_loudly),
+    ("no AWS calls", test_boto3_never_imported),
+]
+
+
+def main():
+    print("=" * 60)
+    print("SIDECAR TESTS")
+    print("=" * 60)
+
+    failed = []
+    for name, test in TESTS:
+        try:
+            passed, detail = test()
+        except Exception as e:  # noqa: BLE001 - a crashing test is a failing test
+            passed, detail = False, f"{type(e).__name__}: {e}"
+
+        if passed:
+            print(f"✅ PASSED: {name}" + (f" - {detail}" if detail else ""))
+        else:
+            print(f"❌ FAILED: {name} - {detail}")
+            failed.append(name)
+
+    print("=" * 60)
+    print(f"Total: {len(TESTS)}  Failed: {len(failed)}")
+    if failed:
+        print("\nFailed tests:")
+        for name in failed:
+            print(f"  - {name}")
+        return 1
+    print("\n🎉 All sidecar tests passed!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a `sidecars:` list to `task_config_yaml`, so a service can run extra containers with their own image, environment, secrets, mounts, ports and health check — all inside the **single** `task-definition.json` that the existing `amazon-ecs-deploy-task-definition` step already registers. No second registration, no second deploy path.

## Why

A downstream service needs a small writable container for the ECS Exec managed agent while its application container keeps `readonlyRootFilesystem: true`. That was impossible before, because `readonly_root_filesystem` was applied as a blanket pass over *every* container. The workaround was to deploy, `describe-task-definition`, patch with `jq`, register a second revision and deploy again — bypassing this action and burning two task-definition revisions per deploy.

```yaml
readonly_root_filesystem: true
writable_dirs: [/tmp]

sidecars:
  - name: ssm-bridge
    image: public.ecr.aws/amazonlinux/amazonlinux@sha256:<pinned-digest>
    command: [sleep, infinity]
    readonly_root_filesystem: false      # overrides the top-level true
    linux_parameters:
      init_process_enabled: true
```

## Design

**Per-container read-only precedence.** The sidecar's own value wins; otherwise the top-level value; otherwise the key is omitted. The application container, its init container, `fluent-bit` and `otel-collector` behave exactly as before.

**Isolation.** A sidecar receives *only* what its own block declares. Application envs, secrets, secret files, writable mounts and ports are never copied in. The one inherited value is `readonly_root_filesystem`, and only as a fallback.

**Prefixed generated names**, so two sidecars can both request a writable `/tmp`:

| | application | sidecar `metrics` |
|---|---|---|
| secret-file init container | `init-container-for-secret-files` | `metrics-secret-init` |
| secret-file volume | `shared-volume` | `metrics-secrets` |
| writable `/tmp` volume | `writable-tmp` | `metrics-writable-tmp` |

**Shared container builder.** `build_container_base` is now the single builder for the skeleton, `stopTimeout`, `logConfiguration`, `healthCheck`, `portMappings` and `linuxParameters` of both the application container and every sidecar; `build_environment` and `build_health_check` were extracted from `generate_task_definition` and shared the same way. Secrets stay ECS `valueFrom` references throughout — never resolved to plaintext.

**Overrides merge by name.** In `services_overrides`, sidecars are matched by `name` rather than appended (appending would produce duplicate container names, which ECS rejects). `enabled: false` switches a base sidecar off for one service.

**Sidecars stay on `awslogs`** even when `fluent_bit_collector` is enabled — consistent with the existing `fluent-bit` and `otel-collector` containers. Routing a sidecar's logs through fluent-bit would hide its diagnostics exactly when fluent-bit is what's broken.

## Validation

All offline, so failures surface before any AWS call instead of mid-deploy from `RegisterTaskDefinition`: unknown/misspelled keys (strict allowlist), duplicate or reserved container names, collisions with *generated* names, invalid or colliding volume names, port-mapping name and container-port collisions across the whole task, ECS port-name grammar, and Fargate CPU/memory budgets.

## Compatibility

**All 31 existing golden outputs are byte-for-byte unchanged** — sidecars are appended after the existing blanket passes, and the new `build_init_containers` / `build_port_mappings` parameters are keyword-only or trailing with defaults equal to today's literals.

## Tests

- 5 new examples with goldens (minimal; read-only + bridge; every feature; two sidecars sharing `/tmp`; per-service override + disable)
- `tests/test_sidecars.py` — 58 cases, wired into CI in both places the workflow runs tests
- 133 tests total pass: 36 goldens, 39 role, 58 sidecar

## Two sharp edges, documented rather than changed

- A sidecar inherits `readonly_root_filesystem: true` but **not** the application's `writable_dirs` (isolation requires it), so a read-only sidecar needing scratch space must declare its own. Called out with a worked example in the docs.
- `command`/`entrypoint` **extend** rather than replace in per-service overrides, matching how the top-level `command` has always merged.

## Also included

`scripts/generate_readme_docs.py` emitted `# Error generating task definition` on every run — several AST-discovered config fields had no curated example value, so they fell through to placeholder strings that failed validation. Fixed, since this change adds a field it discovers.

## Release

Recommend **v0.2.0**. Note that merging triggers `.github/workflows/git-tag.yaml`, which conventional-commit-bumps `v0.1.0` → `v0.2.0` and creates the release **automatically** — so **merge == release**, and review needs to happen before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
